### PR TITLE
Update to v3 of AWS SDK gem

### DIFF
--- a/identity-hostdata.gemspec
+++ b/identity-hostdata.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'aws-sdk-core', "~> 2.10.23"
+  spec.add_dependency 'aws-sdk-s3', '~> 1.8'
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/login_gov/hostdata/s3.rb
+++ b/lib/login_gov/hostdata/s3.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk-core'
+require 'aws-sdk-s3'
 require 'fileutils'
 require 'json'
 require 'logger'
@@ -25,7 +25,11 @@ module LoginGov
       private
 
       def s3_client
-        @s3_client ||= Aws::S3::Client.new(region: region)
+        @s3_client ||= Aws::S3::Client.new(
+          region: region,
+          http_open_timeout: 5,
+          http_read_timeout: 5
+        )
       end
 
       def download_config(s3_path, local_path)


### PR DESCRIPTION
**Why**: To use the latest and greatest, and to only depend on the
gems related to the AWS services we need. This is the recommended
approach when using v3 of the SDK.