### PR TITLE
Use fetch to improve safety of metadata methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.3.3
+
+- Use `Hash#fetch` in `LoginGov::Hostdata::EC2` so that EC2 metadata methods
+  will not return nil if required keys are absent.
+
 # 0.3.2
 
 - Allow overriding `s3_client` in `LoginGov::Hostdata.s3`

--- a/identity-hostdata.gemspec
+++ b/identity-hostdata.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.name          = "identity-hostdata"
   spec.version       = LoginGov::Hostdata::VERSION
   spec.authors       = ["Zach Margolis"]
-  spec.email         = ["zachary.margolis@gsa.gov"]
+  spec.email         = ["identity-devops@login.gov"]
 
   spec.summary       = %q{Library to help read host data for login.gov}
   spec.description   = %q{Common helpers across login.gov infrastructure}

--- a/lib/login_gov/hostdata/ec2.rb
+++ b/lib/login_gov/hostdata/ec2.rb
@@ -2,7 +2,10 @@ require 'net/http'
 
 module LoginGov
   module Hostdata
+    # Class to wrap accessing the EC2 metadata service
     class EC2
+      # Standard initializer
+      #
       # @return [EC2]
       def self.load
         response = http.get('/2016-09-02/dynamic/instance-identity/document')
@@ -20,16 +23,21 @@ module LoginGov
 
       attr_reader :document
 
+      # @param [Hash] document An instance identity document parsed from JSON
+      #   returned by the EC2 metadata service at
+      #   http://169.254.169.254/2016-09-02/dynamic/instance-identity/document
       def initialize(document)
         @document = document
       end
 
+      # @return [String] Current EC2 region
       def region
-        document['region']
+        document.fetch('region')
       end
 
+      # @return [String] Current AWS account ID
       def account_id
-        document['accountId']
+        document.fetch('accountId')
       end
     end
   end

--- a/lib/login_gov/hostdata/version.rb
+++ b/lib/login_gov/hostdata/version.rb
@@ -1,5 +1,6 @@
+# frozen_string_literal: true
 module LoginGov
   module Hostdata
-    VERSION = "0.3.2"
+    VERSION = '0.3.3'
   end
 end


### PR DESCRIPTION
When attempting to discover the region or account ID using the EC2 metadata
service, use fetch to raise KeyError if the instance identity document
doesn't contain the required keys.

These methods should never return nil.