### PR TITLE
Add helper method to read info/role file (instance role)

### DIFF
--- a/identity-hostdata.gemspec
+++ b/identity-hostdata.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'aws-sdk-s3', '~> 1.8'
 
-  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "bundler", ">= 1.15"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "fakefs", "~> 0.11"

--- a/lib/login_gov/hostdata.rb
+++ b/lib/login_gov/hostdata.rb
@@ -9,6 +9,7 @@ module LoginGov
     CONFIG_DIR = '/etc/login.gov'
     DOMAIN_PATH = File.join(CONFIG_DIR, 'info/domain')
     ENV_PATH = File.join(CONFIG_DIR, 'info/env')
+    INSTANCE_ROLE_PATH = File.join(CONFIG_DIR, 'info/role')
 
     def self.domain
       @domain ||= begin
@@ -21,6 +22,14 @@ module LoginGov
     def self.env
       @env ||= begin
         File.read(ENV_PATH).chomp
+      rescue Errno::ENOENT => err
+        raise MissingConfigError, err.message if in_datacenter?
+      end
+    end
+
+    def self.instance_role
+      @env ||= begin
+        File.read(INSTANCE_ROLE_PATH).chomp
       rescue Errno::ENOENT => err
         raise MissingConfigError, err.message if in_datacenter?
       end

--- a/lib/login_gov/hostdata/version.rb
+++ b/lib/login_gov/hostdata/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module LoginGov
   module Hostdata
-    VERSION = '0.3.3'
+    VERSION = '0.4.0'
   end
 end

--- a/spec/login_gov/hostdata_spec.rb
+++ b/spec/login_gov/hostdata_spec.rb
@@ -73,6 +73,36 @@ RSpec.describe LoginGov::Hostdata do
     end
   end
 
+  describe '.instance_role' do
+    context 'when /etc/login.gov exists (in a datacenter environment)' do
+      before { FileUtils.mkdir_p('/etc/login.gov') }
+
+      context 'when the info/role file exists' do
+        before do
+          FileUtils.mkdir_p('/etc/login.gov/info')
+          File.open('/etc/login.gov/info/role', 'w') { |f| f.puts 'migration' }
+        end
+
+        it 'reads the contents of the file' do
+          expect(LoginGov::Hostdata.instance_role).to eq('migration')
+        end
+      end
+
+      context 'when the info/role file does not exist' do
+        it 'blows up' do
+          expect { LoginGov::Hostdata.instance_role }.
+            to raise_error(LoginGov::Hostdata::MissingConfigError)
+        end
+      end
+    end
+
+    context 'when /etc/login.gov does not exist (development environment)' do
+      it 'is nil' do
+        expect(LoginGov::Hostdata.instance_role).to eq(nil)
+      end
+    end
+  end
+
   describe '.in_datacenter?' do
     it 'is true when the /etc/login.gov directory exists' do
       FileUtils.mkdir_p('/etc/login.gov')


### PR DESCRIPTION
I discovered a new "info" file that we were reading manually in the IDP:

https://github.com/18F/identity-idp/blob/master/lib/tasks/check_for_pending_migrations.rake

So let's add a method for it so we can clean up that code!