### PR TITLE
Fix a bug where `instance_role` was memoized as `@env`

### DIFF
--- a/lib/login_gov/hostdata.rb
+++ b/lib/login_gov/hostdata.rb
@@ -28,7 +28,7 @@ module LoginGov
     end
 
     def self.instance_role
-      @env ||= begin
+      @instance_role ||= begin
         File.read(INSTANCE_ROLE_PATH).chomp
       rescue Errno::ENOENT => err
         raise MissingConfigError, err.message if in_datacenter?

--- a/lib/login_gov/hostdata/version.rb
+++ b/lib/login_gov/hostdata/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module LoginGov
   module Hostdata
-    VERSION = '0.4.0'
+    VERSION = '0.4.1'
   end
 end


### PR DESCRIPTION
**Why**: So `instance_role` and `env` don't myseriously have the same value after one is set.