### PR TITLE
memoize in_datacenter method

### DIFF
--- a/lib/login_gov/hostdata.rb
+++ b/lib/login_gov/hostdata.rb
@@ -36,7 +36,8 @@ module LoginGov
     end
 
     def self.in_datacenter?
-      File.directory?(CONFIG_DIR)
+      return @in_datacenter unless @in_datacenter.nil?
+      @in_datacenter = File.directory?(CONFIG_DIR)
     end
 
     # @yield Executes a block if in_datacenter?

--- a/lib/login_gov/hostdata/version.rb
+++ b/lib/login_gov/hostdata/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module LoginGov
   module Hostdata
-    VERSION = '0.4.1'
+    VERSION = '0.4.2'
   end
 end


### PR DESCRIPTION
This function gets used on every page for the banners in the IDP (https://github.com/18F/identity-idp/blob/master/lib/feature_management.rb#L72-L78) and most of the other methods in the module are memoized, so why not do that for `in_datacenter?` to skip some file system effort 🙂

Since the function returns boolean, the usual `||=` syntax doesn't work