### PR TITLE
Adds config, parsing of the <ENV>.json file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # Specify the Ruby version you desire here
-      - image: circleci/ruby:2.3.5
+      - image: circleci/ruby:2.6
 
     working_directory: ~/identity-hostdata
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.3
+
+- Added `LoginGov::Hostdata.config`
+
 # 0.3.3
 
 - Use `Hash#fetch` in `LoginGov::Hostdata::EC2` so that EC2 metadata methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 - Added `LoginGov::Hostdata.config`
 
+# 0.4.1
+
+- Patch memoization bug in `instance_role`
+
+# 0.4.0
+
+- Added `LoginGov::Hostdata.instance_role`
+
 # 0.3.3
 
 - Use `Hash#fetch` in `LoginGov::Hostdata::EC2` so that EC2 metadata methods

--- a/lib/login_gov/hostdata.rb
+++ b/lib/login_gov/hostdata.rb
@@ -36,7 +36,7 @@ module LoginGov
     end
 
     def self.in_datacenter?
-      return @in_datacenter unless @in_datacenter.nil?
+      return @in_datacenter if defined?(@in_datacenter)
       @in_datacenter = File.directory?(CONFIG_DIR)
     end
 

--- a/lib/login_gov/hostdata.rb
+++ b/lib/login_gov/hostdata.rb
@@ -1,6 +1,7 @@
 require "login_gov/hostdata/ec2"
 require "login_gov/hostdata/s3"
 require "login_gov/hostdata/version"
+require "json"
 
 module LoginGov
   module Hostdata
@@ -24,6 +25,22 @@ module LoginGov
         File.read(ENV_PATH).chomp
       rescue Errno::ENOENT => err
         raise MissingConfigError, err.message if in_datacenter?
+      end
+    end
+
+    # @return [Hash] parses the environment's config JSON
+    def self.config
+      @config ||= begin
+        config_path = File.join(
+          CONFIG_DIR,
+          'repos/identity-devops/kitchen/environments',
+          "#{env}.json"
+        )
+
+        JSON.parse(File.read(config_path), symbolize_names: true)
+      rescue Errno::ENOENT => err
+        raise MissingConfigError, err.message if in_datacenter?
+        {}
       end
     end
 

--- a/lib/login_gov/hostdata/version.rb
+++ b/lib/login_gov/hostdata/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module LoginGov
   module Hostdata
-    VERSION = '0.4.2'
+    VERSION = '0.4.3'
   end
 end


### PR DESCRIPTION
This will let us access the `idp_run_migrations` config in the IDP which we can use to be smarter about migrations in fresh environments