### PR TITLE
Configure logging through a railtie

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Add this line to your application's Gemfile:
 
 ```ruby
 gem 'identity-hostdata', github: '18F/identity-hostdata'
+gem 'lograge' # if inside a Rails app, see below
 ```
 
 ## Usage
@@ -34,6 +35,30 @@ end
 ```
 
 [contract]: docs/contract.md
+
+### Usage in a Rails App
+
+This gem includes a Railtie that will configure logging to be more compatible with our log parsing.
+It relies on the `lograge` gem to silence some noisy logging, so your application must also include
+the lograge gem.
+
+It's also that apps add user data to the lograge payload by adding a method in `ApplicationController`:
+
+```ruby
+# application_controller.rb
+
+# for lograge
+def append_info_to_payload(payload)
+  payload[:user_id] = user.id # this depends on your application
+end
+
+```
+
+```ruby
+# config/environments/development.rb
+
+config.lograge.ignore_actions = ['Users::SessionsController#active']
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -42,16 +42,19 @@ This gem includes a Railtie that will configure logging to be more compatible wi
 It relies on the `lograge` gem to silence some noisy logging, so your application must also include
 the lograge gem.
 
-It's also that apps add user data to the lograge payload by adding a method in `ApplicationController`:
+The gem adds some keys to the log payload, and removes ones that often contain sensitive values
+like `headers` and `params`, see [railtie.rb](lib/login_gov/hostdata/railtie.rb) for the specifis.
+
+For apps that have user data, we recommend adding that into to the payload. lograge will
+automatically call `ApplicationController#append_info_to_payload` if it exists. Here's an example:
 
 ```ruby
 # application_controller.rb
 
 # for lograge
 def append_info_to_payload(payload)
-  payload[:user_id] = user.id # this depends on your application
+  payload[:user_id] = user.id # this depends on your application's user model
 end
-
 ```
 
 ```ruby

--- a/identity-hostdata.gemspec
+++ b/identity-hostdata.gemspec
@@ -38,6 +38,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 3.0.1"
   spec.add_development_dependency 'lograge', ">= 0.11.2"
-  spec.add_development_dependency 'rails', '>= 4.0.0'
+  spec.add_development_dependency 'rails', '>= 6.1'
   spec.add_development_dependency 'timecop', ">= 0.9.1"
 end

--- a/identity-hostdata.gemspec
+++ b/identity-hostdata.gemspec
@@ -33,8 +33,11 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aws-sdk-s3', '~> 1.8'
 
   spec.add_development_dependency "bundler", ">= 1.15"
+  spec.add_development_dependency "fakefs", "~> 0.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "fakefs", "~> 0.11"
   spec.add_development_dependency "webmock", "~> 3.0.1"
+  spec.add_development_dependency 'lograge', ">= 0.11.2"
+  spec.add_development_dependency 'rails', '>= 4.0.0'
+  spec.add_development_dependency 'timecop', ">= 0.9.1"
 end

--- a/lib/login_gov/hostdata.rb
+++ b/lib/login_gov/hostdata.rb
@@ -1,7 +1,9 @@
+require "json"
 require "login_gov/hostdata/ec2"
+require "login_gov/hostdata/log_formatter"
 require "login_gov/hostdata/s3"
 require "login_gov/hostdata/version"
-require "json"
+require "login_gov/hostdata/railtie" if defined?(Rails::Railtie)
 
 module LoginGov
   module Hostdata

--- a/lib/login_gov/hostdata/log_formatter.rb
+++ b/lib/login_gov/hostdata/log_formatter.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require 'logger'
+
+module LoginGov
+  module Hostdata
+    class LogFormatter < ::Logger::Formatter
+      # This method is invoked when a log event occurs
+      def call(severity, timestamp, progname, msg)
+        # If message looks like JSON, print it directly. This is a hack to avoid
+        # needing to change the analytics ETL Lambdas that parse the pageview
+        # JSON logs.
+        # If the Analytics ETL lambda is no longer in use or has had more
+        # sophisticated parsing added, then this could be removed.
+        if msg.is_a?(String) && msg.start_with?('{') && msg.end_with?('}')
+          "#{msg}\n"
+        else
+          # Otherwise, use default Ruby log format
+          super
+        end
+      end
+    end
+
+    class DevelopmentLogFormatter < LogFormatter
+      # This method is invoked when a log event occurs
+      def call(severity, timestamp, progname, msg)
+        # If message contains terminal escapes, print it directly. This is useful
+        # in development because rails dev logs contain SQL queries with ANSI
+        # terminal escapes that should be printed as-is without timestamps.
+        if msg.is_a?(String) && msg.include?("\u001b[")
+          "#{msg}\n"
+        else
+          # Otherwise, see parent
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/login_gov/hostdata/railtie.rb
+++ b/lib/login_gov/hostdata/railtie.rb
@@ -5,6 +5,10 @@ rescue LoadError => e
   raise e
 end
 
+if Gem::Version.new(Rails::VERSION::STRING) < Gem::Version.new('6.1')
+  raise 'LoginGov::Hostdata::Railtie needs rails >= 6.1 to log request info, please upgrade'
+end
+
 require 'login_gov/hostdata/log_formatter'
 require 'securerandom'
 

--- a/lib/login_gov/hostdata/railtie.rb
+++ b/lib/login_gov/hostdata/railtie.rb
@@ -1,0 +1,33 @@
+begin
+  require 'lograge'
+rescue LoadError => e
+  STDERR.puts 'lograge is required by the LoginGov::Hostdata::Railtie, please add it to the Gemfile'
+  raise e
+end
+
+require 'login_gov/hostdata/log_formatter'
+require 'securerandom'
+
+module LoginGov
+  module Hostdata
+    class Railtie < Rails::Railtie
+      config.log_formatter = if Rails.env.development?
+        LoginGov::Hostdata::DevelopmentLogFormatter
+      else
+        LoginGov::Hostdata::LogFormatter
+      end
+
+      if Rails.env.development? || Rails.env.production?
+        config.lograge.enabled = true
+        config.lograge.formatter = Lograge::Formatters::Json.new
+      end
+
+      config.lograge.custom_options = lambda do |event|
+        event.payload[:timestamp] = Time.zone.now.iso8601
+        event.payload[:uuid] = SecureRandom.uuid
+        event.payload[:pid] = Process.pid
+        event.payload.except(:params, :headers, :request, :response)
+      end
+    end
+  end
+end

--- a/lib/login_gov/hostdata/railtie.rb
+++ b/lib/login_gov/hostdata/railtie.rb
@@ -11,6 +11,8 @@ require 'securerandom'
 module LoginGov
   module Hostdata
     class Railtie < Rails::Railtie
+      config.lograge.enabled = true
+
       config.log_formatter = if Rails.env.development?
         LoginGov::Hostdata::DevelopmentLogFormatter
       else
@@ -18,7 +20,6 @@ module LoginGov
       end
 
       if Rails.env.development? || Rails.env.production?
-        config.lograge.enabled = true
         config.lograge.formatter = Lograge::Formatters::Json.new
       end
 

--- a/lib/login_gov/hostdata/railtie.rb
+++ b/lib/login_gov/hostdata/railtie.rb
@@ -27,6 +27,10 @@ module LoginGov
         event.payload[:timestamp] = Time.zone.now.iso8601
         event.payload[:uuid] = SecureRandom.uuid
         event.payload[:pid] = Process.pid
+        event.payload[:user_agent] = event.payload[:request].user_agent
+        event.payload[:ip] = event.payload[:request].remote_ip
+        event.payload[:host] = event.payload[:request].host
+        event.payload[:trace_id] = event.payload[:headers]['X-Amzn-Trace-Id']
         event.payload.except(:params, :headers, :request, :response)
       end
     end

--- a/lib/login_gov/hostdata/version.rb
+++ b/lib/login_gov/hostdata/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module LoginGov
   module Hostdata
-    VERSION = '0.4.3'
+    VERSION = '1.0.0'
   end
 end

--- a/spec/login_gov/hostdata/log_formatter_spec.rb
+++ b/spec/login_gov/hostdata/log_formatter_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+require 'login_gov/hostdata/log_formatter'
+
+RSpec.describe LoginGov::Hostdata::LogFormatter do
+  subject(:log_formatter) { described_class.new }
+
+  describe '#call' do
+    it 'prints expected standard messages' do
+      now = Time.utc(2019, 1, 2, 3, 4, 5)
+      expect(log_formatter.call('INFO', now, 'progname', 'hello')).
+        to eq("I, [2019-01-02T03:04:05.000000 ##{Process.pid}]  INFO -- progname: hello\n")
+    end
+
+    it 'prints JSON-like messages as-is' do
+      expect(log_formatter.call('INFO', Time.now, 'progname', '{"hello"}')).
+        to eq('{"hello"}' + "\n")
+    end
+  end
+end
+
+RSpec.describe LoginGov::Hostdata::DevelopmentLogFormatter do
+  subject(:log_formatter) { described_class.new }
+
+  describe '#call' do
+    it 'prints ANSI escaped messages as-is' do
+      now = Time.utc(2019, 1, 2, 3, 4, 5)
+      msg = "\e[1;31mhello\e[m"
+      expect(log_formatter.call('INFO', now, 'progname', msg)).
+        to eq(msg + "\n")
+    end
+
+    it 'prints expected messages otherwise' do
+      now = Time.utc(2019, 1, 2, 3, 4, 5)
+      expect(log_formatter.call('INFO', now, 'progname', 'hello')).
+        to eq("I, [2019-01-02T03:04:05.000000 ##{Process.pid}]  INFO -- progname: hello\n")
+    end
+  end
+end

--- a/spec/login_gov/hostdata/railtie_spec.rb
+++ b/spec/login_gov/hostdata/railtie_spec.rb
@@ -1,0 +1,57 @@
+require 'rails'
+require 'timecop'
+require 'active_support/core_ext/time'
+require 'login_gov/hostdata/railtie'
+
+RSpec.describe LoginGov::Hostdata::Railtie do
+  around do |ex|
+    zone = Time.zone
+    Time.zone = ActiveSupport::TimeZone['UTC']
+    ex.run
+    Time.zone = zone
+  end
+
+  describe 'config.lograge.custom_options' do
+    subject(:config) { LoginGov::Hostdata::Railtie.config }
+
+    let(:event) do
+      ActiveSupport::Notifications::Event.new(
+        'process_action.action_controller',
+        start,
+        finish,
+        transaction_id,
+        controller: 'Users::SessionsController',
+        action: 'new',
+        request: Rack::Request.new(headers),
+        params: { foo: 'bar' },
+        headers: headers,
+        path: '/',
+        response: instance_double(ActionDispatch::Response),
+      )
+    end
+
+    let(:start) { Time.zone.now }
+    let(:finish) { Time.zone.now }
+    let(:transaction_id) { SecureRandom.uuid }
+    let(:amzn_trace_id) { SecureRandom.hex }
+    let(:headers) { {} }
+    let(:now) { Time.zone.now }
+
+    it 'adds in timestamp, uuid, and pid, trace_id and omits extra noise' do
+      payload = Timecop.freeze(now) do
+        config.lograge.custom_options.call(event)
+      end
+
+      expect(payload).to_not include(:params, :headers, :request, :response)
+
+      expect(payload).to match(
+        timestamp: now.iso8601,
+        uuid: /\A[0-9a-f-]+\Z/, # rough UUID regex
+        pid: Process.pid,
+        controller: 'Users::SessionsController',
+        action: 'new',
+        path: '/',
+      )
+    end
+  end
+end


### PR DESCRIPTION
Problem:
- I wanted to make logging in our other apps like the IDP's, using lograge and JSON formatting. See previous PR https://github.com/18F/identity-dashboard/pull/392
- I forgot to copy over UpayaLogFormatter, which trims some extra timestamps from the output

Solution:
- Let's share code via our gem!

I have some questions about this approach I'd like to get feedback on, will tag those specific locations