### PR TITLE
Add legacy namespace to smooth transition in config repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.1
+
+- Add backwards-compatible `LoginGov` namespace back to smooth out
+  transition in config repo
+
 # 1.0.0
 
 - Rename `LoginGov` namespace back to `Identity` (big breaking change)

--- a/lib/identity/hostdata/version.rb
+++ b/lib/identity/hostdata/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Identity
   module Hostdata
-    VERSION = '1.0.0'
+    VERSION = '1.0.1'
   end
 end

--- a/lib/login_gov/hostdata.rb
+++ b/lib/login_gov/hostdata.rb
@@ -1,0 +1,6 @@
+require 'identity/hostdata'
+
+# Create an alias with the old LoginGov namespace so we don't break some of our configs
+module LoginGov
+  Hostdata = ::Identity::Hostdata
+end

--- a/spec/identity/hostdata_spec.rb
+++ b/spec/identity/hostdata_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe 'backwards-compatible name' do
+  it 'exists' do
+    expect do
+      require 'login_gov/hostdata'
+      LoginGov::Hostdata.env
+    end.to_not raise_error
+  end
+end


### PR DESCRIPTION
If we don't do this, I am pretty sure that our deploys will break because of this line in the config:

https://github.com/18F/identity-idp-config/blob/d4c0abad42ceae1a6bf95423824e439dbd0e82d0/service_providers.yml#L266-L267

