### PR TITLE
Add Identity::Hostdata.settings, to store data from config (LG-4247)

### DIFF
--- a/lib/identity/hostdata.rb
+++ b/lib/identity/hostdata.rb
@@ -15,7 +15,7 @@ module Identity
 
     # @param [Hash] configuration
     # @param [String] rails_env from +Rails.env+
-    # Sets up Identity::Hosdata.settings, should be called before that is accessed
+    # Sets up Identity::Hostdata.settings, should be called before that is accessed
     def self.setup_settings!(configuration:, rails_env:)
       @settings = Settings.new(configuration: configuration, rails_env: rails_env)
     end

--- a/lib/identity/hostdata.rb
+++ b/lib/identity/hostdata.rb
@@ -1,5 +1,6 @@
 require "identity/hostdata/ec2"
 require "identity/hostdata/s3"
+require "identity/hostdata/settings"
 require "identity/hostdata/version"
 require "json"
 
@@ -12,6 +13,14 @@ module Identity
     ENV_PATH = File.join(CONFIG_DIR, 'info/env')
     INSTANCE_ROLE_PATH = File.join(CONFIG_DIR, 'info/role')
 
+    # @param [Hash] configuration
+    # @param [String] rails_env from +Rails.env+
+    # Sets up Identity::Hosdata.settings, should be called before that is accessed
+    def self.setup_settings!(configuration:, rails_env:)
+      @settings = Settings.new(configuration: configuration, rails_env: rails_env)
+    end
+
+    # @return [String,nil]
     def self.domain
       @domain ||= begin
         File.read(DOMAIN_PATH).chomp
@@ -20,6 +29,7 @@ module Identity
       end
     end
 
+    # @return [String,nil]
     def self.env
       @env ||= begin
         File.read(ENV_PATH).chomp
@@ -44,6 +54,7 @@ module Identity
       end
     end
 
+    # @return [String,nil]
     def self.instance_role
       @instance_role ||= begin
         File.read(INSTANCE_ROLE_PATH).chomp
@@ -52,6 +63,7 @@ module Identity
       end
     end
 
+    # @return [Boolean]
     def self.in_datacenter?
       return @in_datacenter if defined?(@in_datacenter)
       @in_datacenter = File.directory?(CONFIG_DIR)
@@ -86,6 +98,8 @@ module Identity
       alias_method :default_logger, :logger
 
       attr_writer :logger
+
+      attr_reader :settings
     end
 
     # @api private

--- a/lib/identity/hostdata.rb
+++ b/lib/identity/hostdata.rb
@@ -20,7 +20,7 @@ module Identity
       @settings = Settings.new(configuration: configuration, rails_env: rails_env)
     end
 
-    # @return [String,nil]
+    # @return [String]
     def self.domain
       @domain ||= begin
         File.read(DOMAIN_PATH).chomp
@@ -29,7 +29,7 @@ module Identity
       end
     end
 
-    # @return [String,nil]
+    # @return [String]
     def self.env
       @env ||= begin
         File.read(ENV_PATH).chomp
@@ -54,7 +54,7 @@ module Identity
       end
     end
 
-    # @return [String,nil]
+    # @return [String]
     def self.instance_role
       @instance_role ||= begin
         File.read(INSTANCE_ROLE_PATH).chomp

--- a/lib/identity/hostdata.rb
+++ b/lib/identity/hostdata.rb
@@ -15,9 +15,14 @@ module Identity
 
     # @param [Hash] configuration
     # @param [String] rails_env from +Rails.env+
+    # @param [Boolean] write_to_env whether or not we should write values from the config to ENV
     # Sets up Identity::Hostdata.settings, should be called before that is accessed
-    def self.setup_settings!(configuration:, rails_env:)
-      @settings = Settings.new(configuration: configuration, rails_env: rails_env)
+    def self.setup_settings!(configuration:, rails_env:, write_to_env: false)
+      @settings = Settings.new(
+        configuration: configuration,
+        rails_env: rails_env,
+        write_to_env: write_to_env
+      )
     end
 
     # @return [String]

--- a/lib/identity/hostdata/settings.rb
+++ b/lib/identity/hostdata/settings.rb
@@ -7,7 +7,8 @@ module Identity
 
       # @param [Hash] configuration
       # @param [String] rails_env from +Rails.env+
-      def initialize(configuration:, rails_env:)
+      # @param [Boolean] write_to_env whether or not we should write values from the config to ENV
+      def initialize(configuration:, rails_env:, write_to_env: false)
         @config = {}
 
         keys = Set.new(configuration.keys - %w[production development test])
@@ -25,7 +26,7 @@ module Identity
             @config[key] = env_value
           else
             @config[key] = value
-            ENV[key] = value
+            ENV[key] = value if write_to_env
           end
         end
       end

--- a/lib/identity/hostdata/settings.rb
+++ b/lib/identity/hostdata/settings.rb
@@ -1,0 +1,68 @@
+module Identity
+  module Hostdata
+    # Handles reading settings and configuration from a YAML file, allows
+    # overriding via ENV vars
+    class Settings
+      attr_reader :config
+
+      # @param [Hash] configuration
+      # @param [String] rails_env from +Rails.env+
+      def initialize(configuration:, rails_env:)
+        @config = {}
+
+        keys = Set.new(configuration.keys - %w[production development test])
+        keys |= configuration[rails_env]&.keys || []
+
+        keys.each do |key|
+          value = configuration.dig(rails_env, key) || configuration[key]
+          env_value = ENV[key]
+
+          check_string_key(key)
+          check_string_value(key, value)
+
+          if env_value
+            warn "WARNING: #{key} is being loaded from ENV instead of application.yml"
+            @config[key] = env_value
+          else
+            @config[key] = value
+            ENV[key] = value
+          end
+        end
+      end
+
+      def require_keys(keys)
+        keys.each do |key|
+          raise "#{key} is missing" unless @config.key?(key)
+        end
+
+        true
+      end
+
+      def respond_to?(method_name)
+        key = method_name.to_s
+        @config.key?(key)
+      end
+
+      private
+
+      def check_string_key(key)
+        warn "AppConfig WARNING: key #{key} must be String" unless key.is_a?(String)
+      end
+
+      def check_string_value(key, value)
+        warn "AppConfig WARNING: #{key} value must be String" unless value.nil? || value.is_a?(String)
+      end
+
+      def respond_to_missing?(method_name, _include_private = false)
+        key = method_name.to_s
+        @config.key?(key)
+      end
+
+      def method_missing(method, *_args)
+        key = method.to_s
+
+        @config[key]
+      end
+    end
+  end
+end

--- a/lib/identity/hostdata/version.rb
+++ b/lib/identity/hostdata/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Identity
   module Hostdata
-    VERSION = '1.0.1'
+    VERSION = '1.1.0'
   end
 end

--- a/spec/identity/hostdata/settings_spec.rb
+++ b/spec/identity/hostdata/settings_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Identity::Hostdata::Settings do
       },
     }
   end
+  let(:write_to_env) { false }
 
   before do
     stub_const('ENV', {})
@@ -19,6 +20,7 @@ RSpec.describe Identity::Hostdata::Settings do
     Identity::Hostdata::Settings.new(
       configuration: configuration,
       rails_env: rails_env,
+      write_to_env: write_to_env,
     )
   end
 
@@ -72,8 +74,20 @@ RSpec.describe Identity::Hostdata::Settings do
       end
     end
 
-    it 'sets ENV' do
-      expect { settings }.to(change { ENV['test_key'] }.to('value'))
+    context 'when write_to_env is true' do
+      let(:write_to_env) { true }
+
+      it 'sets ENV' do
+        expect { settings }.to(change { ENV['test_key'] }.to('value'))
+      end
+    end
+
+    context 'when write_to_env is false' do
+      let(:write_to_env) { false }
+
+      it 'sets ENV' do
+        expect { settings }.to_not(change { ENV['test_key'] })
+      end
     end
   end
 

--- a/spec/identity/hostdata/settings_spec.rb
+++ b/spec/identity/hostdata/settings_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+RSpec.describe Identity::Hostdata::Settings do
+  let(:rails_env) { 'test' }
+  let(:configuration) do
+    {
+      'test_key' => 'value',
+      'production' => {
+        'test_key' => 'overridden value',
+      },
+    }
+  end
+
+  before do
+    stub_const('ENV', {})
+  end
+
+  subject(:settings) do
+    Identity::Hostdata::Settings.new(
+      configuration: configuration,
+      rails_env: rails_env,
+    )
+  end
+
+  describe '#initialize' do
+    it 'warns and uses ENV when key is set in ENV and file config' do
+      ENV['test_key'] = 'aaa'
+      expect do
+        expect(settings.test_key).to eq('aaa')
+      end.to output(
+        /test_key is being loaded from ENV/,
+      ).to_stderr
+    end
+
+    context 'when a config value is not a string' do
+      let(:configuration) do
+        {
+          'test_key' => 1,
+        }
+      end
+
+      it 'warns if config value is not a string' do
+        expect do
+          settings
+        end.to output(
+          /test_key value must be String/,
+        ).to_stderr
+      end
+    end
+
+    context 'when a config key is not a string' do
+      let(:configuration) do
+        {
+          1 => 'test',
+        }
+      end
+
+      it 'warns if config value is not a string' do
+        expect do
+          settings
+        end.to output(
+          /key 1 must be String/,
+        ).to_stderr
+      end
+    end
+
+    context 'in a specific environment' do
+      let(:rails_env) { 'production' }
+
+      it 'overrides from specified environment key' do
+        expect(settings.test_key).to eq('overridden value')
+      end
+    end
+
+    it 'sets ENV' do
+      expect { settings }.to(change { ENV['test_key'] }.to('value'))
+    end
+  end
+
+  describe '#method_missing' do
+    it 'reads from configuration' do
+      expect(settings.test_key).to eq(configuration['test_key'])
+    end
+  end
+
+  describe '#require_keys' do
+    it 'does not raise an error if required keys are set' do
+      expect(settings.require_keys(['test_key'])).to eq true
+    end
+
+    it 'raises an error if required key is not set' do
+      expect { settings.require_keys(['unset_key']) }.to raise_error(
+        RuntimeError,
+        'unset_key is missing',
+      )
+    end
+  end
+end

--- a/spec/identity/hostdata_spec.rb
+++ b/spec/identity/hostdata_spec.rb
@@ -13,6 +13,19 @@ RSpec.describe Identity::Hostdata do
     end
   end
 
+  describe '.setup_settings!' do
+    it 'sets settings' do
+      expect do
+        Identity::Hostdata.setup_settings!(
+          configuration: { 'some_key' => 'some_value'},
+          rails_env: 'test',
+        )
+      end.to(
+        change { Identity::Hostdata.settings }.from(nil).to(kind_of(Identity::Hostdata::Settings))
+      )
+    end
+  end
+
   describe '.domain' do
     context 'when /etc/login.gov exists (in a datacenter environment)' do
       before { FileUtils.mkdir_p('/etc/login.gov') }

--- a/spec/identity/hostdata_spec.rb
+++ b/spec/identity/hostdata_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe Identity::Hostdata do
   end
 
   describe '.setup_settings!' do
+    before do
+      stub_const('ENV', {})
+    end
+
     it 'sets settings' do
       expect do
         Identity::Hostdata.setup_settings!(
@@ -23,6 +27,16 @@ RSpec.describe Identity::Hostdata do
       end.to(
         change { Identity::Hostdata.settings }.from(nil).to(kind_of(Identity::Hostdata::Settings))
       )
+    end
+
+    it 'writes to ENV when write_to_env is true' do
+      expect do
+        Identity::Hostdata.setup_settings!(
+          configuration: { 'some_key' => 'some_value'},
+          rails_env: 'test',
+          write_to_env: true,
+        )
+      end.to(change { ENV['some_key'] }.to('some_value'))
     end
   end
 


### PR DESCRIPTION
Lifted work from https://github.com/18f/identity-idp/pull/4408

Next steps:
- Update the IDP to do a giant `s/AppConfig.env/Identity::Hostdata.settings/g`
- Update PKI, Dashboard

The biggest bummer was that we already have `Identity::Hostdata.config` and `Identity::Hostdata.env`... which are great names for what this does, so I went with settings. Very open to other naming ideas!