### PR TITLE
Allow the hostdata configurations and AWS configurations to be overridden by env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.0.0
+
+- Add the ability to override hostdata values with env vars
+
 # 2.0.0
 
 - Change the API that negotiates with S3 to differentiate between the secrets

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -15,11 +15,11 @@ Outside of a chef configured environment, this gem will use env vars for configu
 The `/etc/login.gov` directory or env vars can be accessed through `Identity::Hostdata` class methods.
 
 | File | Env var | API | Example |
-| ---- | --- | ------- |
+| ---- | --- | --- | ------- |
 | `/etc/login.gov/info/env` | `LOGIN_ENV` | `Identity::Hostdata.env` | `"int"` |
 | `/etc/login.gov/info/domain` | `LOGIN_DOMAIN` | `Identity::Hostdata.domain` | `"login.gov"` |
-| `/etc/login.gov/info/role` | `LOGIN_HOST_ROLE` | `Identity::Hostdata.instance_role` | `"login.gov"` |
-| `/etc/login.gov/repos/identity-devops/kitchen/environments/$ENV.json` | LOGIN_HOST_CONFIG | `Identity::Hostdata.config` | `"login.gov"` |
+| `/etc/login.gov/info/role` | `LOGIN_HOST_ROLE` | `Identity::Hostdata.instance_role` | `"worker"` |
+| `/etc/login.gov/repos/identity-devops/kitchen/environments/$ENV.json` | LOGIN_HOST_CONFIG | `Identity::Hostdata.config` | [Example here](https://github.com/18F/identity-devops/blob/main/kitchen/environments/environment.json.template) |
 
 Additionally, if env vars are being used you will want to set `LOGIN_DATACENTER` to true in production. This will make `Identity::Hostdata.in_datacenter?` return true.
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -23,16 +23,6 @@ The `/etc/login.gov` directory or env vars can be accessed through `Identity::Ho
 
 Additionally, if env vars are being used you will want to set `LOGIN_DATACENTER` to true in production. This will make `Identity::Hostdata.in_datacenter?` return true.
 
-### Configuration via env vars
-
-To configure the app with env vars, add the following environment variables:
-
-- `LOGIN_DATACENTER`: The value `true` to indicate the IDP is in production in a deployed environment
-- `LOGIN_ENV`: The environment the app is running in (e.g. `int`, `staging`, or `prod`)
-- `LOGIN_DOMAIN`: The domain of the current app (e.g. `idp.int.identitysandbox.gov`)
-- `LOGIN_HOST_ROLE`: The role of the current host, (e.g. `idp`, `workder`, `pivcac`)
-- `LOGIN_HOST_CONFIG`: Host specific configurations (A template is available here: [https://github.com/18F/identity-devops/blob/main/kitchen/environments/environment.json.template](https://github.com/18F/identity-devops/blob/main/kitchen/environments/environment.json.template))
-
 ## AWS host information
 
 Apps may need to know about the AWS environment they are configured to run in or alongside.

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,6 +1,18 @@
 # login.gov infrastructure contract
 
-## `/etc/login.gov`
+This gem is built to support an app in 2 deployment schemes:
+
+1. In a chef provisioned environment using EC2 metadata and files on the disk
+2. In a non-chef provisioned environment that is configured using environment variables
+
+## Host configurations
+
+In a chef configured environment, this gem can read configurations from files that are added
+to `/etc/login.gov` by chef.
+
+Outside of a chef configured environment, this gem will use env vars for configuration
+
+### Configuration via `/etc/login.gov`
 
 The `/etc/login.gov` directory will exist on deployed instanes of login.gov apps. It contains individual files with useful data, and can be accessed through `Identity::Hostdata` class methods
 
@@ -9,25 +21,46 @@ The `/etc/login.gov` directory will exist on deployed instanes of login.gov apps
 | `/etc/login.gov/info/env` | `Identity::Hostdata.env` | `"int"` |
 | `/etc/login.gov/info/domain` | `Identity::Hostdata.domain` | `"login.gov"` |
 
-## EC2 instance metadata
+### Configuration via env vars
+
+To configure the app with env vars, add the following environment variables:
+
+- `LOGIN_DATACENTER`: The value `true` to indicate the IDP is in production in a deployed environment
+- `LOGIN_ENV`: The environment the app is running in (e.g. `int`, `staging`, or `prod`)
+- `LOGIN_DOMAIN`: The domain of the current app (e.g. `idp.int.identitysandbox.gov`)
+- `LOGIN_HOST_ROLE`: The role of the current host, (e.g. `idp`, `workder`, `pivcac`)
+- `LOGIN_HOST_CONFIG`: Host specific configurations (A template is available here: [https://github.com/18F/identity-devops/blob/main/kitchen/environments/environment.json.template](https://github.com/18F/identity-devops/blob/main/kitchen/environments/environment.json.template))
+
+## AWS host information
+
+Apps may need to know about the AWS environment they are configured to run in or alongside.
+If the app is running on an EC2 instance in AWS, it can read the EC2 metadata to determine the region or account ID.
+If the app is not running on an EC2 instance in AWs, it can read configurations from ENV vars
+
+### EC2 instance metadata
 
 We use [instance metadata][instance-metadata] (an HTTP request from an EC2 box) to populate basic information about our instances in EC2.
 
 - region
 - account ID
 
-The [Identity::Hostdata::EC2](../lib/identity/hostdata/ec2.rb) class helps load and read this data:
+The [Identity::Hostdata](../lib/identity/hostdata/hostdata.rb) module helps load and read this data:
 
 ```ruby
-ec2_data = Identity::Hostdata::EC2.load
-# => #<Identity::Hostdata::EC2:0x00007fc49dd30f40 ...>
-ec2_data.region
+Identity::Hostdata.aws_region
 # => "us-west-1"
-ec2_data.account_id
+Identity::Hostdata.aws_account_id
 # => "12345"
 ```
 
 [instance-metadata]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
+
+### AWS environment vars
+
+If the app is not running on an EC2 instance, then the configs for the AWS environment can be set with the following env vars:
+
+- `LOGIN_AWS_REGION`: The AWS region (named to avoid conflicting with `AWS_REGION`)
+- `LOGIN_AWS_ACCOUNT_ID`: The AWS account ID
 
 ## Files stored in S3
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -19,7 +19,7 @@ The `/etc/login.gov` directory or env vars can be accessed through `Identity::Ho
 | `/etc/login.gov/info/env` | `LOGIN_ENV` | `Identity::Hostdata.env` | `"int"` |
 | `/etc/login.gov/info/domain` | `LOGIN_DOMAIN` | `Identity::Hostdata.domain` | `"login.gov"` |
 | `/etc/login.gov/info/role` | `LOGIN_HOST_ROLE` | `Identity::Hostdata.instance_role` | `"worker"` |
-| `/etc/login.gov/repos/identity-devops/kitchen/environments/$ENV.json` | LOGIN_HOST_CONFIG | `Identity::Hostdata.config` | [Example here](https://github.com/18F/identity-devops/blob/main/kitchen/environments/environment.json.template) |
+| `/etc/login.gov/repos/identity-devops/kitchen/environments/$ENV.json` | `LOGIN_HOST_CONFIG` | `Identity::Hostdata.config` | [Example here](https://github.com/18F/identity-devops/blob/main/kitchen/environments/environment.json.template) |
 
 Additionally, if env vars are being used you will want to set `LOGIN_DATACENTER` to true in production. This will make `Identity::Hostdata.in_datacenter?` return true.
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -12,14 +12,16 @@ to `/etc/login.gov` by chef.
 
 Outside of a chef configured environment, this gem will use env vars for configuration
 
-### Configuration via `/etc/login.gov`
+The `/etc/login.gov` directory or env vars can be accessed through `Identity::Hostdata` class methods.
 
-The `/etc/login.gov` directory will exist on deployed instanes of login.gov apps. It contains individual files with useful data, and can be accessed through `Identity::Hostdata` class methods
-
-| File | API | Example |
+| File | Env var | API | Example |
 | ---- | --- | ------- |
-| `/etc/login.gov/info/env` | `Identity::Hostdata.env` | `"int"` |
-| `/etc/login.gov/info/domain` | `Identity::Hostdata.domain` | `"login.gov"` |
+| `/etc/login.gov/info/env` | `LOGIN_ENV` | `Identity::Hostdata.env` | `"int"` |
+| `/etc/login.gov/info/domain` | `LOGIN_DOMAIN` | `Identity::Hostdata.domain` | `"login.gov"` |
+| `/etc/login.gov/info/role` | `LOGIN_HOST_ROLE` | `Identity::Hostdata.instance_role` | `"login.gov"` |
+| `/etc/login.gov/repos/identity-devops/kitchen/environments/$ENV.json` | LOGIN_HOST_CONFIG | `Identity::Hostdata.config` | `"login.gov"` |
+
+Additionally, if env vars are being used you will want to set `LOGIN_DATACENTER` to true in production. This will make `Identity::Hostdata.in_datacenter?` return true.
 
 ### Configuration via env vars
 

--- a/lib/identity/hostdata.rb
+++ b/lib/identity/hostdata.rb
@@ -70,12 +70,17 @@ module Identity
 
     # @return [String]
     def self.aws_region
-      @aws_region ||= ENV['LOGIN_AWS_REGION'] ||  Identity::Hostdata::EC2.load.region
+      @aws_region ||= ENV['LOGIN_AWS_REGION'] || ec2.region
     end
 
     # @return [String]
     def self.aws_account_id
-      @aws_account_id ||= ENV['LOGIN_AWS_ACCOUNT_ID'] || Identity::Hostdata::EC2.load.account_id
+      @aws_account_id ||= ENV['LOGIN_AWS_ACCOUNT_ID'] || ec2.account_id
+    end
+
+    # @return [EC2]
+    def self.ec2
+      @ec2 = Identity::Hostdata::EC2.load
     end
 
     # @return [S3] An S3 object configured to use the app-secrets bucket

--- a/lib/identity/hostdata.rb
+++ b/lib/identity/hostdata.rb
@@ -14,47 +14,44 @@ module Identity
 
     # @return [String]
     def self.domain
-      @domain ||= begin
-        ENV['LOGIN_DOMAIN'] || File.read(File.join(root.to_s, DOMAIN_PATH)).chomp
-      rescue Errno::ENOENT => err
-        raise MissingConfigError, err.message if in_datacenter?
-      end
+      return @domain if defined?(@domain)
+      @domain = ENV['LOGIN_DOMAIN'] || File.read(File.join(root.to_s, DOMAIN_PATH)).chomp
+    rescue Errno::ENOENT => err
+      raise MissingConfigError, err.message if in_datacenter?
     end
 
     # @return [String]
     def self.env
-      @env ||= begin
-        ENV['LOGIN_ENV'] || File.read(File.join(root.to_s, ENV_PATH)).chomp
-      rescue Errno::ENOENT => err
-        raise MissingConfigError, err.message if in_datacenter?
-      end
+      return @env if defined?(@env)
+      @env = ENV['LOGIN_ENV'] || File.read(File.join(root.to_s, ENV_PATH)).chomp
+    rescue Errno::ENOENT => err
+      raise MissingConfigError, err.message if in_datacenter?
     end
 
     # @return [Hash] parses the environment's config JSON
     def self.config
-      @config ||= begin
-        config_path = File.join(
-          root.to_s,
-          CONFIG_DIR,
-          'repos/identity-devops/kitchen/environments',
-          "#{env}.json"
-        )
-        config_contents = ENV['LOGIN_HOST_CONFIG'] || File.read(config_path)
+      return @config if defined?(@config)
 
-        JSON.parse(config_contents, symbolize_names: true)
-      rescue Errno::ENOENT => err
-        raise MissingConfigError, err.message if in_datacenter?
-        {}
-      end
+      config_path = File.join(
+        root.to_s,
+        CONFIG_DIR,
+        'repos/identity-devops/kitchen/environments',
+        "#{env}.json"
+      )
+      config_contents = ENV['LOGIN_HOST_CONFIG'] || File.read(config_path)
+
+      @config = JSON.parse(config_contents, symbolize_names: true)
+    rescue Errno::ENOENT => err
+      raise MissingConfigError, err.message if in_datacenter?
+      {}
     end
 
     # @return [String]
     def self.instance_role
-      @instance_role ||= begin
-        ENV['LOGIN_HOST_ROLE'] || File.read(File.join(root.to_s, INSTANCE_ROLE_PATH)).chomp
-      rescue Errno::ENOENT => err
-        raise MissingConfigError, err.message if in_datacenter?
-      end
+      return @instance_role if defined?(@instance_role)
+      @instance_role = ENV['LOGIN_HOST_ROLE'] || File.read(File.join(root.to_s, INSTANCE_ROLE_PATH)).chomp
+    rescue Errno::ENOENT => err
+      raise MissingConfigError, err.message if in_datacenter?
     end
 
     # @return [Boolean]

--- a/lib/identity/hostdata.rb
+++ b/lib/identity/hostdata.rb
@@ -80,7 +80,7 @@ module Identity
 
     # @return [EC2]
     def self.ec2
-      @ec2 = Identity::Hostdata::EC2.load
+      @ec2 ||= Identity::Hostdata::EC2.load
     end
 
     # @return [S3] An S3 object configured to use the app-secrets bucket

--- a/lib/identity/hostdata/version.rb
+++ b/lib/identity/hostdata/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Identity
   module Hostdata
-    VERSION = '2.0.0'
+    VERSION = '3.0.0'
   end
 end

--- a/spec/identity/hostdata_spec.rb
+++ b/spec/identity/hostdata_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe Identity::Hostdata do
     end
   end
 
+  let(:env) { {} }
+
+  before do
+    stub_const('ENV', env)
+  end
+
   describe '.domain' do
     context 'when /etc/login.gov exists (in a datacenter environment)' do
       before { FileUtils.mkdir_p("#{@root}/etc/login.gov") }
@@ -39,12 +45,7 @@ RSpec.describe Identity::Hostdata do
     end
 
     context 'when the LOGIN_DOMAIN env var is set' do
-      before do
-        stub_const(
-          'ENV',
-          { 'LOGIN_DOMAIN' => 'identityenvbox.gov', 'LOGIN_DATACENTER' => 'true' },
-        )
-      end
+      let(:env) { { 'LOGIN_DOMAIN' => 'identityenvbox.gov', 'LOGIN_DATACENTER' => 'true' } }
 
       it 'reads the value of the env var' do
         expect(Identity::Hostdata.domain).to eq('identityenvbox.gov')
@@ -82,12 +83,7 @@ RSpec.describe Identity::Hostdata do
     end
 
     context 'when the LOGIN_ENV env var is set' do
-      before do
-        stub_const(
-          'ENV',
-          { 'LOGIN_ENV' => 'dev', 'LOGIN_DATACENTER' => 'true' },
-        )
-      end
+      let(:env) { { 'LOGIN_ENV' => 'dev', 'LOGIN_DATACENTER' => 'true' } }
 
       it 'reads the value of the env var' do
         expect(Identity::Hostdata.env).to eq('dev')
@@ -117,12 +113,7 @@ RSpec.describe Identity::Hostdata do
       end
 
       context 'when the LOGIN_HOST_ROLE env var is set' do
-        before do
-          stub_const(
-            'ENV',
-            { 'LOGIN_HOST_ROLE' => 'worker', 'LOGIN_DATACENTER' => 'true' },
-          )
-        end
+        let(:env) { { 'LOGIN_HOST_ROLE' => 'worker', 'LOGIN_DATACENTER' => 'true' } }
 
         it 'reads the value of the env var' do
           expect(Identity::Hostdata.instance_role).to eq('worker')
@@ -146,9 +137,9 @@ RSpec.describe Identity::Hostdata do
 
   describe '#aws_region' do
     context 'when the LOGIN_AWS_REGION env var is set' do
-      it 'returns the env var value' do
-        stub_const('ENV', 'LOGIN_AWS_REGION' => 'us-west-2')
+      let(:env) { { 'LOGIN_AWS_REGION' => 'us-west-2' } }
 
+      it 'returns the env var value' do
         expect(Identity::Hostdata.aws_region).to eq('us-west-2')
       end
     end
@@ -168,9 +159,9 @@ RSpec.describe Identity::Hostdata do
 
   describe '#aws_account_id' do
     context 'when the LOGIN_AWS_ACCOUNT_ID env var is set' do
-      it 'returns the env var value' do
-        stub_const('ENV', 'LOGIN_AWS_ACCOUNT_ID' => '67890')
+      let(:env) { { 'LOGIN_AWS_ACCOUNT_ID' => '67890' } }
 
+      it 'returns the env var value' do
         expect(Identity::Hostdata.aws_account_id).to eq('67890')
       end
     end
@@ -196,7 +187,9 @@ RSpec.describe Identity::Hostdata do
     end
 
     it 'is true when the HOSTDATA_DATACENTER var is set to "true"' do
-      stub_const('ENV', 'LOGIN_DATACENTER' => 'true')
+      env['LOGIN_DATACENTER'] = 'true'
+
+      expect(Identity::Hostdata.in_datacenter?).to eq(true)
     end
 
     it 'is false when the /etc/login.gov does not exist' do
@@ -279,15 +272,13 @@ RSpec.describe Identity::Hostdata do
     end
 
     context 'when the LOGIN_HOST_CONFIG env var is set' do
-      before do
-        stub_const(
-          'ENV',
-          {
-            'LOGIN_HOST_CONFIG' => config_data.to_json,
-            'LOGIN_DATACENTER' => 'true',
-            'LOGIN_ENV' => 'staging',
-          },
-        )
+
+      let(:env) do
+        {
+          'LOGIN_HOST_CONFIG' => config_data.to_json,
+          'LOGIN_DATACENTER' => 'true',
+          'LOGIN_ENV' => 'staging',
+        }
       end
 
       it 'parses and returns the config in the env' do


### PR DESCRIPTION
**Why**: So they can be explicitly configured to still work outside of a chef provisioned environment or AWS environment where we don't have access to EC2 metadata.