### PR TITLE
Add a ConfigReader class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.1.0
+
+- Add a ConfigReader class which can be used to parse configs from application.yml
+
 # 3.0.0
 
 - Add the ability to override hostdata values with env vars

--- a/identity-hostdata.gemspec
+++ b/identity-hostdata.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency 'activesupport', '~> 6.1'
   spec.add_dependency 'aws-sdk-s3', '~> 1.8'
 
   spec.add_development_dependency "bundler", ">= 1.15"

--- a/lib/identity/hostdata.rb
+++ b/lib/identity/hostdata.rb
@@ -1,3 +1,4 @@
+require "identity/hostdata/config_reader"
 require "identity/hostdata/ec2"
 require "identity/hostdata/s3"
 require "identity/hostdata/version"

--- a/lib/identity/hostdata/config_reader.rb
+++ b/lib/identity/hostdata/config_reader.rb
@@ -92,10 +92,6 @@ module Identity
         end
       end
 
-      def symbolize_keys(hash)
-
-      end
-
       def deep_merge(hash_a, hash_b)
         hash_a.merge(hash_b) do |key, a_val, b_val|
           if a_val.is_a?(Hash) && b_val.is_a?(Hash)

--- a/lib/identity/hostdata/config_reader.rb
+++ b/lib/identity/hostdata/config_reader.rb
@@ -49,7 +49,7 @@ module Identity
                       elsif File.exists?(local_config_filepath)
                         File.read(local_config_filepath)
                       end
-        YAML.safe_load(raw_configs || '{}')
+        YAML.safe_load(raw_configs || '{}') || {}
       end
 
       def role_override_configuration
@@ -62,7 +62,7 @@ module Identity
                         File.read(local_config_filepath)
                       end
 
-        YAML.safe_load(raw_configs || '{}')
+        YAML.safe_load(raw_configs || '{}') || {}
       end
 
       def app_secrets_s3

--- a/lib/identity/hostdata/config_reader.rb
+++ b/lib/identity/hostdata/config_reader.rb
@@ -26,7 +26,7 @@ module Identity
         base_configs.delete('test')
         base_configs.merge(
           base_configuration[rails_env],
-        )
+        ).transform_keys(&:to_sym)
       end
 
       private
@@ -90,6 +90,10 @@ module Identity
         when 'worker'
           'worker.yml'
         end
+      end
+
+      def symbolize_keys(hash)
+
       end
 
       def deep_merge(hash_a, hash_b)

--- a/lib/identity/hostdata/config_reader.rb
+++ b/lib/identity/hostdata/config_reader.rb
@@ -1,0 +1,106 @@
+module Identity
+  module Hostdata
+    class ConfigReader
+      attr_reader :app_root, :logger
+
+      def initialize(
+        app_root: Rails.root,
+        s3_client: nil,
+        logger: Logger.new(STDOUT)
+      )
+        @app_root = app_root
+        @s3_client = s3_client
+        @logger = logger
+      end
+
+      def read_configuration(rails_env, write_copy_to: nil)
+        if write_copy_to && !File.exists?(write_copy_to)
+          FileUtils.mkdir_p(File.dirname(write_copy_to))
+          File.write(write_copy_to, base_configuration.to_yaml)
+          FileUtils.chmod(0o640, write_copy_to)
+        end
+
+        base_configs = base_configuration.dup
+        base_configs.delete('development')
+        base_configs.delete('production')
+        base_configs.delete('test')
+        base_configs.merge(
+          base_configuration[rails_env],
+        )
+      end
+
+      private
+
+      def base_configuration
+        @base_configuration ||= deep_merge(
+          deep_merge(default_configuration, app_override_configuration),
+          role_override_configuration,
+        )
+      end
+
+      def default_configuration
+        YAML.safe_load(File.read(File.join(app_root, 'config', 'application.yml.default')))
+      end
+
+      def app_override_configuration
+        local_config_filepath = File.join(app_root, 'config', 'application.yml')
+        raw_configs = if Identity::Hostdata.in_datacenter?
+                        app_secrets_s3.read_file(app_configuration_s3_path)
+                      elsif File.exists?(local_config_filepath)
+                        File.read(local_config_filepath)
+                      end
+        YAML.safe_load(raw_configs || '{}')
+      end
+
+      def role_override_configuration
+        return {} if role_configuration_filename.nil?
+        local_config_filepath = File.join(app_root, 'config', role_configuration_filename)
+
+        raw_configs = if Identity::Hostdata.in_datacenter?
+                        app_secrets_s3.read_file(role_configuration_s3_path)
+                      elsif File.exists?(local_config_filepath)
+                        File.read(local_config_filepath)
+                      end
+
+        YAML.safe_load(raw_configs || '{}')
+      end
+
+      def app_secrets_s3
+        @app_secrets_s3 ||= Identity::Hostdata.app_secrets_s3(logger: @logger, s3_client: @s3_client)
+      end
+
+      def app_configuration_s3_path
+        "/%<env>s/#{app_configuration_path_component}/v1/application.yml"
+      end
+
+      def role_configuration_s3_path
+        return if role_configuration_filename.nil?
+        "/%<env>s/#{app_configuration_path_component}/v1/#{role_configuration_filename}"
+      end
+
+      def app_configuration_path_component
+        return 'idp' if Identity::Hostdata.instance_role == 'worker'
+        Identity::Hostdata.instance_role
+      end
+
+      def role_configuration_filename
+        case Identity::Hostdata.instance_role
+        when 'idp'
+          'web.yml'
+        when 'worker'
+          'worker.yml'
+        end
+      end
+
+      def deep_merge(hash_a, hash_b)
+        hash_a.merge(hash_b) do |key, a_val, b_val|
+          if a_val.is_a?(Hash) && b_val.is_a?(Hash)
+            deep_merge(a_val, b_val)
+          else
+            b_val || a_val
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/identity/hostdata/version.rb
+++ b/lib/identity/hostdata/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Identity
   module Hostdata
-    VERSION = '3.0.0'
+    VERSION = '3.1.0'
   end
 end

--- a/spec/identity/hostdata/config_reader_spec.rb
+++ b/spec/identity/hostdata/config_reader_spec.rb
@@ -1,0 +1,187 @@
+require 'spec_helper'
+
+RSpec.describe Identity::Hostdata::ConfigReader do
+  DEFAULT_YAML = <<~HEREDOC
+    base_config: 'test'
+    overriden_env_config: 'override me' # Overriden below for development'
+    overriden_base_config: 'override me' # Overriden in application.yml
+    overriden_role_config: 'only override me on workers' # Overriden in worker.yml
+
+    development:
+      env_config: 'test'
+      overriden_env_config: 'test'
+  HEREDOC
+
+  OVERRIDE_YAML = <<~HEREDOC
+    development:
+      overriden_base_config: 'test'
+  HEREDOC
+
+  ROLE_YAML = <<~HEREDOC
+    development:
+      overriden_role_config: 'test'
+  HEREDOC
+
+  let(:app_root) { @app_root }
+
+  around(:each) do |ex|
+    Dir.mktmpdir do |app_root|
+      @app_root = app_root
+      set_tmp_dir_fixtures(app_root)
+      ex.run
+    end
+  end
+
+  let(:logger) { Logger.new('/dev/null') }
+  let(:s3_client) { nil }
+
+  subject(:reader) { described_class.new(app_root: app_root, logger: logger, s3_client: s3_client) }
+
+  context 'in the datacenter' do
+    let(:s3_client) { Aws::S3::Client.new(stub_responses: true) }
+    let(:s3_contents) do
+      {
+        'int/idp/v1/application.yml' => OVERRIDE_YAML,
+        'int/idp/v1/worker.yml' => ROLE_YAML,
+      }
+    end
+
+    before do
+      allow(Identity::Hostdata).to receive(:in_datacenter?).and_return(true)
+      allow(Identity::Hostdata).to receive(:instance_role).and_return('idp')
+      allow(Identity::Hostdata).to receive(:env).and_return('int')
+
+      stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
+        to_return(body: {
+          'region' => 'us-west-1',
+          'accountId' => '12345',
+        }.to_json)
+
+      s3_client.stub_responses(
+        :get_object, proc do |context|
+          key = context.params[:key]
+          body = s3_contents[key]
+          if body
+            { body: body }
+          else
+            raise Aws::S3::Errors::NoSuchKey.new(nil, nil)
+          end
+        end
+      )
+      allow(s3_client).to receive(:get_object).and_call_original
+    end
+
+    it 'merges the default and override yaml values' do
+      configuration = reader.read_configuration('development')
+
+      expect(s3_client).to have_received(:get_object).with(
+        hash_including(key: 'int/idp/v1/application.yml'),
+      )
+      expect(configuration).to eq(
+        'base_config' => 'test',
+        'env_config' => 'test',
+        'overriden_env_config' => 'test',
+        'overriden_base_config' => 'test',
+        'overriden_role_config' => 'only override me on workers',
+      )
+    end
+
+    it 'merges the role configs if they exist' do
+      allow(Identity::Hostdata).to receive(:instance_role).and_return('worker')
+
+      configuration = reader.read_configuration('development')
+
+      expect(s3_client).to have_received(:get_object).with(
+        hash_including(key: 'int/idp/v1/application.yml'),
+      )
+      expect(s3_client).to have_received(:get_object).with(
+        hash_including(key: 'int/idp/v1/worker.yml'),
+      )
+      expect(configuration).to eq(
+        'base_config' => 'test',
+        'env_config' => 'test',
+        'overriden_env_config' => 'test',
+        'overriden_base_config' => 'test',
+        'overriden_role_config' => 'test',
+      )
+    end
+
+    context 'on idps' do
+      it 'resolves the s3 paths correctly' do
+        allow(Identity::Hostdata).to receive(:instance_role).and_return('idp')
+
+        s3_contents['int/idp/v1/application.yml'] = 'config1: hello'
+        s3_contents['int/idp/v1/web.yml'] = 'config2: world'
+
+        expect(s3_client).to receive(:get_object).with(
+          hash_including(key: 'int/idp/v1/application.yml')
+        ).and_call_original
+        expect(s3_client).to receive(:get_object).with(
+          hash_including(key: 'int/idp/v1/web.yml')
+        ).and_call_original
+
+        configuration = reader.read_configuration('development')
+
+        expect(configuration['config1']).to eq('hello')
+        expect(configuration['config2']).to eq('world')
+      end
+    end
+
+    context 'on workers' do
+      it 'resolves the s3 paths correctly' do
+        allow(Identity::Hostdata).to receive(:instance_role).and_return('worker')
+
+        s3_contents['int/idp/v1/application.yml'] = 'config1: hello'
+        s3_contents['int/idp/v1/worker.yml'] = 'config2: world'
+
+        expect(s3_client).to receive(:get_object).with(
+          hash_including(key: 'int/idp/v1/application.yml')
+        ).and_call_original
+        expect(s3_client).to receive(:get_object).with(
+          hash_including(key: 'int/idp/v1/worker.yml')
+        ).and_call_original
+
+        configuration = reader.read_configuration('development')
+
+        expect(configuration['config1']).to eq('hello')
+        expect(configuration['config2']).to eq('world')
+      end
+    end
+
+    context 'on pivcacs' do
+      it 'resolves the s3 paths correctly' do
+        allow(Identity::Hostdata).to receive(:instance_role).and_return('pivcac')
+
+        s3_contents['int/pivcac/v1/application.yml'] = 'config1: hello'
+
+        expect(s3_client).to receive(:get_object).with(
+          hash_including(key: 'int/pivcac/v1/application.yml')
+        ).and_call_original
+
+        configuration = reader.read_configuration('development')
+
+        expect(configuration['config1']).to eq('hello')
+      end
+    end
+  end
+
+  context 'during local dev' do
+    it 'merges the default and override configurations' do
+      configuration = reader.read_configuration('development')
+
+      expect(configuration).to eq(
+        'base_config' => 'test',
+        'env_config' => 'test',
+        'overriden_env_config' => 'test',
+        'overriden_base_config' => 'test',
+        'overriden_role_config' => 'only override me on workers',
+      )
+    end
+  end
+
+  def set_tmp_dir_fixtures(root)
+    FileUtils.mkdir_p(File.join(root, 'config'))
+    File.write(File.join(root, 'config', 'application.yml.default'), DEFAULT_YAML)
+    File.write(File.join(root, 'config', 'application.yml'), OVERRIDE_YAML)
+  end
+end

--- a/spec/identity/hostdata/config_reader_spec.rb
+++ b/spec/identity/hostdata/config_reader_spec.rb
@@ -78,11 +78,11 @@ RSpec.describe Identity::Hostdata::ConfigReader do
         hash_including(key: 'int/idp/v1/application.yml'),
       )
       expect(configuration).to eq(
-        'base_config' => 'test',
-        'env_config' => 'test',
-        'overriden_env_config' => 'test',
-        'overriden_base_config' => 'test',
-        'overriden_role_config' => 'only override me on workers',
+        base_config: 'test',
+        env_config: 'test',
+        overriden_env_config: 'test',
+        overriden_base_config: 'test',
+        overriden_role_config: 'only override me on workers',
       )
     end
 
@@ -98,11 +98,11 @@ RSpec.describe Identity::Hostdata::ConfigReader do
         hash_including(key: 'int/idp/v1/worker.yml'),
       )
       expect(configuration).to eq(
-        'base_config' => 'test',
-        'env_config' => 'test',
-        'overriden_env_config' => 'test',
-        'overriden_base_config' => 'test',
-        'overriden_role_config' => 'test',
+        base_config: 'test',
+        env_config: 'test',
+        overriden_env_config: 'test',
+        overriden_base_config: 'test',
+        overriden_role_config: 'test',
       )
     end
 
@@ -122,8 +122,8 @@ RSpec.describe Identity::Hostdata::ConfigReader do
 
         configuration = reader.read_configuration('development')
 
-        expect(configuration['config1']).to eq('hello')
-        expect(configuration['config2']).to eq('world')
+        expect(configuration[:config1]).to eq('hello')
+        expect(configuration[:config2]).to eq('world')
       end
     end
 
@@ -143,8 +143,8 @@ RSpec.describe Identity::Hostdata::ConfigReader do
 
         configuration = reader.read_configuration('development')
 
-        expect(configuration['config1']).to eq('hello')
-        expect(configuration['config2']).to eq('world')
+        expect(configuration[:config1]).to eq('hello')
+        expect(configuration[:config2]).to eq('world')
       end
     end
 
@@ -160,7 +160,7 @@ RSpec.describe Identity::Hostdata::ConfigReader do
 
         configuration = reader.read_configuration('development')
 
-        expect(configuration['config1']).to eq('hello')
+        expect(configuration[:config1]).to eq('hello')
       end
     end
   end
@@ -170,11 +170,11 @@ RSpec.describe Identity::Hostdata::ConfigReader do
       configuration = reader.read_configuration('development')
 
       expect(configuration).to eq(
-        'base_config' => 'test',
-        'env_config' => 'test',
-        'overriden_env_config' => 'test',
-        'overriden_base_config' => 'test',
-        'overriden_role_config' => 'only override me on workers',
+        base_config: 'test',
+        env_config: 'test',
+        overriden_env_config: 'test',
+        overriden_base_config: 'test',
+        overriden_role_config: 'only override me on workers',
       )
     end
   end


### PR DESCRIPTION
**Why**: So the hostdata gem can manage the footwork involved with downloading configs and parsing them. This will enable us to use the hostdata gem to consume configs in a consistent manner across host types.