### PR TITLE
Correct the path component for the dashboard application.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.1.1
+
+- Fix a bug where the dashboard application.yml path was not resolved correctly
+
 # 3.1.0
 
 - Add a ConfigReader class which can be used to parse configs from application.yml

--- a/lib/identity/hostdata/config_reader.rb
+++ b/lib/identity/hostdata/config_reader.rb
@@ -86,6 +86,7 @@ module Identity
 
       def app_configuration_path_component
         return 'idp' if Identity::Hostdata.instance_role == 'worker'
+        return 'dashboard' if Identity::Hostdata.instance_role == 'app'
         Identity::Hostdata.instance_role
       end
 

--- a/lib/identity/hostdata/version.rb
+++ b/lib/identity/hostdata/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Identity
   module Hostdata
-    VERSION = '3.1.0'
+    VERSION = '3.1.1'
   end
 end

--- a/spec/identity/hostdata/config_reader_spec.rb
+++ b/spec/identity/hostdata/config_reader_spec.rb
@@ -163,6 +163,22 @@ RSpec.describe Identity::Hostdata::ConfigReader do
         expect(configuration[:config1]).to eq('hello')
       end
     end
+
+    context 'on dashboards' do
+      it 'resolves the s3 paths correctly' do
+        allow(Identity::Hostdata).to receive(:instance_role).and_return('app')
+
+        s3_contents['int/dashboard/v1/application.yml'] = 'config1: hello'
+
+        expect(s3_client).to receive(:get_object).with(
+          hash_including(key: 'int/dashboard/v1/application.yml')
+        ).and_call_original
+
+        configuration = reader.read_configuration('development')
+
+        expect(configuration[:config1]).to eq('hello')
+      end
+    end
   end
 
   context 'during local dev' do


### PR DESCRIPTION
**Why**: When `Hostdata#instance_role` is invoked on dashboards it returns `app` but the application.yml uses `dashboard` in its path