### PR TITLE
Fix the S3 paths when the instance role is migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.1.2
+
+- Fix a bug where the migration application.yml path was not resolved correctly
+
 # 3.1.1
 
 - Fix a bug where the dashboard application.yml path was not resolved correctly

--- a/lib/identity/hostdata/config_reader.rb
+++ b/lib/identity/hostdata/config_reader.rb
@@ -86,6 +86,7 @@ module Identity
 
       def app_configuration_path_component
         return 'idp' if Identity::Hostdata.instance_role == 'worker'
+        return 'idp' if Identity::Hostdata.instance_role == 'migration'
         return 'dashboard' if Identity::Hostdata.instance_role == 'app'
         Identity::Hostdata.instance_role
       end

--- a/lib/identity/hostdata/version.rb
+++ b/lib/identity/hostdata/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Identity
   module Hostdata
-    VERSION = '3.1.1'
+    VERSION = '3.1.2'
   end
 end

--- a/spec/identity/hostdata/config_reader_spec.rb
+++ b/spec/identity/hostdata/config_reader_spec.rb
@@ -148,6 +148,23 @@ RSpec.describe Identity::Hostdata::ConfigReader do
       end
     end
 
+    context 'on migration instances' do
+      it 'resolves the s3 paths correctly' do
+        allow(Identity::Hostdata).to receive(:instance_role).and_return('migration')
+
+        s3_contents['int/idp/v1/application.yml'] = 'config1: hello'
+        s3_contents['int/idp/v1/worker.yml'] = 'config2: world'
+
+        expect(s3_client).to receive(:get_object).with(
+          hash_including(key: 'int/idp/v1/application.yml')
+        ).and_call_original
+
+        configuration = reader.read_configuration('development')
+
+        expect(configuration[:config1]).to eq('hello')
+      end
+    end
+
     context 'on pivcacs' do
       it 'resolves the s3 paths correctly' do
         allow(Identity::Hostdata).to receive(:instance_role).and_return('pivcac')


### PR DESCRIPTION
**Why**: Because the configs for migrations live under the `idp` prefix in S3