### PR TITLE
Update to use v2 instance metadata service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.1.3
+- Update to use V2 of the ec2 instance metadata service
+
 # 3.1.2
 
 - Fix a bug where the migration application.yml path was not resolved correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-# 3.1.3
-- Update to use V2 of the ec2 instance metadata service
+# 3.2.0
+
+- Update to use V2 of the EC2 instance metadata service
 
 # 3.1.2
 

--- a/lib/identity/hostdata/ec2.rb
+++ b/lib/identity/hostdata/ec2.rb
@@ -23,8 +23,7 @@ module Identity
 
       # get token
       def self.v2_token
-        token = Net::HTTP.new('169.254.169.254', 80)
-        http.put('/latest/api/token', nil, { 'X-aws-ec2-metadata-token-ttl-seconds': "60" }).body
+        http.put('/latest/api/token', nil, 'X-aws-ec2-metadata-token-ttl-seconds' => '60').body.chomp
       end 
 
       attr_reader :document

--- a/lib/identity/hostdata/ec2.rb
+++ b/lib/identity/hostdata/ec2.rb
@@ -8,7 +8,7 @@ module Identity
       #
       # @return [EC2]
       def self.load
-        response = http.get('/2016-09-02/dynamic/instance-identity/document')
+        response = http.get('/2016-09-02/dynamic/instance-identity/document', { 'X-aws-ec2-metadata-token' => v2_token })
         new(JSON.parse(response.body))
       end
 
@@ -20,6 +20,12 @@ module Identity
         http.open_timeout = 1
         http
       end
+
+      # get token
+      def self.v2_token
+        token = Net::HTTP.new('169.254.169.254', 80)
+        http.put('/latest/api/token', nil, { 'X-aws-ec2-metadata-token-ttl-seconds': "60" }).body
+      end 
 
       attr_reader :document
 

--- a/lib/identity/hostdata/ec2.rb
+++ b/lib/identity/hostdata/ec2.rb
@@ -8,7 +8,7 @@ module Identity
       #
       # @return [EC2]
       def self.load
-        response = http.get('/2016-09-02/dynamic/instance-identity/document', { 'X-aws-ec2-metadata-token' => v2_token })
+        response = http.get('/2016-09-02/dynamic/instance-identity/document', 'X-aws-ec2-metadata-token' => v2_token)
         new(JSON.parse(response.body))
       end
 

--- a/lib/identity/hostdata/version.rb
+++ b/lib/identity/hostdata/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Identity
   module Hostdata
-    VERSION = '3.1.2'
+    VERSION = '3.1.3'
   end
 end

--- a/lib/identity/hostdata/version.rb
+++ b/lib/identity/hostdata/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Identity
   module Hostdata
-    VERSION = '3.1.3'
+    VERSION = '3.2.0'
   end
 end

--- a/spec/identity/hostdata/config_reader_spec.rb
+++ b/spec/identity/hostdata/config_reader_spec.rb
@@ -51,11 +51,15 @@ RSpec.describe Identity::Hostdata::ConfigReader do
       allow(Identity::Hostdata).to receive(:instance_role).and_return('idp')
       allow(Identity::Hostdata).to receive(:env).and_return('int')
 
+      stub_request(:put, "http://169.254.169.254/latest/api/token").
+          with(headers: {'X-Aws-Ec2-Metadata-Token-Ttl-Seconds'=>'60'}).
+          to_return(body: "bhasdkjhas82")
       stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
-        to_return(body: {
-          'region' => 'us-west-1',
-          'accountId' => '12345',
-        }.to_json)
+          with(headers: { 'X-aws-ec2-metadata-token' => 'bhasdkjhas82' }).
+          to_return(body: {
+            'region' => 'us-west-1',
+            'accountId' => '12345',
+          }.to_json)
 
       s3_client.stub_responses(
         :get_object, proc do |context|

--- a/spec/identity/hostdata/config_reader_spec.rb
+++ b/spec/identity/hostdata/config_reader_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Identity::Hostdata::ConfigReader do
       allow(Identity::Hostdata).to receive(:instance_role).and_return('idp')
       allow(Identity::Hostdata).to receive(:env).and_return('int')
 
-      stub_request(:put, "http://169.254.169.254/latest/api/token").
+      stub_request(:put, 'http://169.254.169.254/latest/api/token').
           with(headers: { 'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '60' }).
           to_return(body: "bhasdkjhas82")
       stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').

--- a/spec/identity/hostdata/config_reader_spec.rb
+++ b/spec/identity/hostdata/config_reader_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Identity::Hostdata::ConfigReader do
       allow(Identity::Hostdata).to receive(:env).and_return('int')
 
       stub_request(:put, "http://169.254.169.254/latest/api/token").
-          with(headers: {'X-Aws-Ec2-Metadata-Token-Ttl-Seconds'=>'60'}).
+          with(headers: { 'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '60' }).
           to_return(body: "bhasdkjhas82")
       stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
           with(headers: { 'X-aws-ec2-metadata-token' => 'bhasdkjhas82' }).

--- a/spec/identity/hostdata/ec2_spec.rb
+++ b/spec/identity/hostdata/ec2_spec.rb
@@ -5,7 +5,11 @@ RSpec.describe Identity::Hostdata::EC2 do
     subject(:load) { Identity::Hostdata::EC2.load }
 
     it 'loads data from the magic ECS URL' do
+      stub_request(:put, "http://169.254.169.254/latest/api/token").
+          with(headers: {'X-Aws-Ec2-Metadata-Token-Ttl-Seconds'=>'60'}).
+          to_return(body: "bhasdkjhas82")
       stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
+        with(headers: { 'X-aws-ec2-metadata-token' => 'bhasdkjhas82' }).
         to_return(body: document.to_json)
 
       ec2 = load
@@ -13,7 +17,11 @@ RSpec.describe Identity::Hostdata::EC2 do
     end
 
     it 'blows up when the request times out' do
+      stub_request(:put, "http://169.254.169.254/latest/api/token").
+          with(headers: {'X-Aws-Ec2-Metadata-Token-Ttl-Seconds'=>'60'}).
+          to_return(body: "bhasdkjhas82")
       stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
+        with(headers: { 'X-aws-ec2-metadata-token' => 'bhasdkjhas82' }).
         to_timeout
 
       expect { load }.to raise_error(Net::OpenTimeout)

--- a/spec/identity/hostdata/ec2_spec.rb
+++ b/spec/identity/hostdata/ec2_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Identity::Hostdata::EC2 do
 
     it 'loads data from the magic ECS URL' do
       stub_request(:put, 'http://169.254.169.254/latest/api/token').
-          with(headers: {'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '60'}).
+          with(headers: { 'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '60' }).
           to_return(body: "bhasdkjhas82")
       stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
         with(headers: { 'X-aws-ec2-metadata-token' => 'bhasdkjhas82' }).
@@ -18,7 +18,7 @@ RSpec.describe Identity::Hostdata::EC2 do
 
     it 'blows up when the request times out' do
       stub_request(:put, 'http://169.254.169.254/latest/api/token').
-          with(headers: {'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '60'}).
+          with(headers: { 'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '60' }).
           to_return(body: "bhasdkjhas82")
       stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
         with(headers: { 'X-aws-ec2-metadata-token' => 'bhasdkjhas82' }).

--- a/spec/identity/hostdata/ec2_spec.rb
+++ b/spec/identity/hostdata/ec2_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Identity::Hostdata::EC2 do
     subject(:load) { Identity::Hostdata::EC2.load }
 
     it 'loads data from the magic ECS URL' do
-      stub_request(:put, "http://169.254.169.254/latest/api/token").
-          with(headers: {'X-Aws-Ec2-Metadata-Token-Ttl-Seconds'=>'60'}).
+      stub_request(:put, 'http://169.254.169.254/latest/api/token).
+          with(headers: {'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '60'}).
           to_return(body: "bhasdkjhas82")
       stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
         with(headers: { 'X-aws-ec2-metadata-token' => 'bhasdkjhas82' }).

--- a/spec/identity/hostdata/ec2_spec.rb
+++ b/spec/identity/hostdata/ec2_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Identity::Hostdata::EC2 do
     subject(:load) { Identity::Hostdata::EC2.load }
 
     it 'loads data from the magic ECS URL' do
-      stub_request(:put, 'http://169.254.169.254/latest/api/token).
+      stub_request(:put, 'http://169.254.169.254/latest/api/token').
           with(headers: {'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '60'}).
           to_return(body: "bhasdkjhas82")
       stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
@@ -17,8 +17,8 @@ RSpec.describe Identity::Hostdata::EC2 do
     end
 
     it 'blows up when the request times out' do
-      stub_request(:put, "http://169.254.169.254/latest/api/token").
-          with(headers: {'X-Aws-Ec2-Metadata-Token-Ttl-Seconds'=>'60'}).
+      stub_request(:put, 'http://169.254.169.254/latest/api/token').
+          with(headers: {'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '60'}).
           to_return(body: "bhasdkjhas82")
       stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
         with(headers: { 'X-aws-ec2-metadata-token' => 'bhasdkjhas82' }).

--- a/spec/identity/hostdata_spec.rb
+++ b/spec/identity/hostdata_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe Identity::Hostdata do
     context 'when a region env var is not set' do
       it 'uses the EC2 instance metadata' do
         stub_request(:put, 'http://169.254.169.254/latest/api/token').
-          with(headers: {'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '60'}).
+          with(headers: { 'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '60' }).
           to_return(body: "bhasdkjhas82")
         stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
           with(headers: { 'X-aws-ec2-metadata-token' => 'bhasdkjhas82' }).
@@ -303,8 +303,8 @@ RSpec.describe Identity::Hostdata do
 
   describe '.app_secrets_s3' do
     before do
-      stub_request(:put, "http://169.254.169.254/latest/api/token").
-          with(headers: {'X-Aws-Ec2-Metadata-Token-Ttl-Seconds'=>'60'}).
+      stub_request(:put, 'http://169.254.169.254/latest/api/token').
+          with(headers: {'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '60'}).
           to_return(body: "bhasdkjhas82")
       stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
         with(headers: { 'X-aws-ec2-metadata-token' => 'bhasdkjhas82' }).
@@ -348,8 +348,8 @@ RSpec.describe Identity::Hostdata do
 
   describe '.secrets_s3' do
     before do
-      stub_request(:put, "http://169.254.169.254/latest/api/token").
-        with(headers: {'X-Aws-Ec2-Metadata-Token-Ttl-Seconds'=>'60'}).
+      stub_request(:put, 'http://169.254.169.254/latest/api/token').
+        with(headers: { 'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '60' }).
         to_return(body: "bhasdkjhas82")
       stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
         with(headers: { 'X-aws-ec2-metadata-token' => 'bhasdkjhas82' }).

--- a/spec/identity/hostdata_spec.rb
+++ b/spec/identity/hostdata_spec.rb
@@ -146,7 +146,11 @@ RSpec.describe Identity::Hostdata do
 
     context 'when a region env var is not set' do
       it 'uses the EC2 instance metadata' do
+        stub_request(:put, "http://169.254.169.254/latest/api/token").
+          with(headers: {'X-Aws-Ec2-Metadata-Token-Ttl-Seconds'=>'60'}).
+          to_return(body: "bhasdkjhas82")
         stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
+          with(headers: { 'X-aws-ec2-metadata-token' => 'bhasdkjhas82' }).
           to_return(body: {
             'accountId' => '12345',
             'region' => 'us-east-1',
@@ -168,7 +172,11 @@ RSpec.describe Identity::Hostdata do
 
     context 'when an account id env var is not set' do
       it 'uses the EC2 instance metadata' do
+        stub_request(:put, "http://169.254.169.254/latest/api/token").
+          with(headers: {'X-Aws-Ec2-Metadata-Token-Ttl-Seconds'=>'60'}).
+          to_return(body: "bhasdkjhas82")
         stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
+          with(headers: { 'X-aws-ec2-metadata-token' => 'bhasdkjhas82' }).
           to_return(body: {
             'accountId' => '12345',
             'region' => 'us-east-1',
@@ -295,7 +303,11 @@ RSpec.describe Identity::Hostdata do
 
   describe '.app_secrets_s3' do
     before do
+      stub_request(:put, "http://169.254.169.254/latest/api/token").
+          with(headers: {'X-Aws-Ec2-Metadata-Token-Ttl-Seconds'=>'60'}).
+          to_return(body: "bhasdkjhas82")
       stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
+        with(headers: { 'X-aws-ec2-metadata-token' => 'bhasdkjhas82' }).
         to_return(body: {
           'accountId' => '12345',
           'region' => 'us-east-1',
@@ -336,7 +348,11 @@ RSpec.describe Identity::Hostdata do
 
   describe '.secrets_s3' do
     before do
+      stub_request(:put, "http://169.254.169.254/latest/api/token").
+        with(headers: {'X-Aws-Ec2-Metadata-Token-Ttl-Seconds'=>'60'}).
+        to_return(body: "bhasdkjhas82")
       stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
+        with(headers: { 'X-aws-ec2-metadata-token' => 'bhasdkjhas82' }).
         to_return(body: {
           'accountId' => '12345',
           'region' => 'us-east-1',
@@ -366,7 +382,6 @@ RSpec.describe Identity::Hostdata do
 
     context 'with a logger param' do
       let(:logger) { Logger.new(STDOUT) }
-
       subject(:s3) { Identity::Hostdata.secrets_s3(logger: logger) }
 
       it 'passes the logger through' do

--- a/spec/identity/hostdata_spec.rb
+++ b/spec/identity/hostdata_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe Identity::Hostdata do
     context 'when an account id env var is not set' do
       it 'uses the EC2 instance metadata' do
         stub_request(:put, 'http://169.254.169.254/latest/api/token').
-          with(headers: {'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '60'}).
+          with(headers: { 'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '60' }).
           to_return(body: "bhasdkjhas82")
         stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
           with(headers: { 'X-aws-ec2-metadata-token' => 'bhasdkjhas82' }).
@@ -304,7 +304,7 @@ RSpec.describe Identity::Hostdata do
   describe '.app_secrets_s3' do
     before do
       stub_request(:put, 'http://169.254.169.254/latest/api/token').
-          with(headers: {'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '60'}).
+          with(headers: { 'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '60' }).
           to_return(body: "bhasdkjhas82")
       stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
         with(headers: { 'X-aws-ec2-metadata-token' => 'bhasdkjhas82' }).

--- a/spec/identity/hostdata_spec.rb
+++ b/spec/identity/hostdata_spec.rb
@@ -146,8 +146,8 @@ RSpec.describe Identity::Hostdata do
 
     context 'when a region env var is not set' do
       it 'uses the EC2 instance metadata' do
-        stub_request(:put, "http://169.254.169.254/latest/api/token").
-          with(headers: {'X-Aws-Ec2-Metadata-Token-Ttl-Seconds'=>'60'}).
+        stub_request(:put, 'http://169.254.169.254/latest/api/token').
+          with(headers: {'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '60'}).
           to_return(body: "bhasdkjhas82")
         stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
           with(headers: { 'X-aws-ec2-metadata-token' => 'bhasdkjhas82' }).
@@ -172,8 +172,8 @@ RSpec.describe Identity::Hostdata do
 
     context 'when an account id env var is not set' do
       it 'uses the EC2 instance metadata' do
-        stub_request(:put, "http://169.254.169.254/latest/api/token").
-          with(headers: {'X-Aws-Ec2-Metadata-Token-Ttl-Seconds'=>'60'}).
+        stub_request(:put, 'http://169.254.169.254/latest/api/token').
+          with(headers: {'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '60'}).
           to_return(body: "bhasdkjhas82")
         stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
           with(headers: { 'X-aws-ec2-metadata-token' => 'bhasdkjhas82' }).


### PR DESCRIPTION
Devops issue https://github.com/18F/identity-devops/issues/2948
Use version 2 of ec2 instance metadata service.