### PR TITLE
Stop AWS S3 from calculating MD5 checksums, not FIPS-supported

### DIFF
--- a/lib/identity/hostdata/s3.rb
+++ b/lib/identity/hostdata/s3.rb
@@ -53,7 +53,7 @@ module Identity
         @s3_client ||= Aws::S3::Client.new(
           region: region,
           http_open_timeout: 5,
-          http_read_timeout: 5
+          http_read_timeout: 5,
           signature_version: 'v4',
           compute_checksums: false,
         )

--- a/lib/identity/hostdata/s3.rb
+++ b/lib/identity/hostdata/s3.rb
@@ -54,7 +54,6 @@ module Identity
           region: region,
           http_open_timeout: 5,
           http_read_timeout: 5,
-          signature_version: 'v4',
           compute_checksums: false,
         )
       end

--- a/lib/identity/hostdata/s3.rb
+++ b/lib/identity/hostdata/s3.rb
@@ -54,6 +54,8 @@ module Identity
           region: region,
           http_open_timeout: 5,
           http_read_timeout: 5
+          signature_version: 'v4',
+          compute_checksums: false,
         )
       end
     end

--- a/lib/identity/hostdata/version.rb
+++ b/lib/identity/hostdata/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Identity
   module Hostdata
-    VERSION = '3.2.0'
+    VERSION = '3.3.0'
   end
 end


### PR DESCRIPTION
This S3 client is used almost exclusively for reading config data, but seems like it couldn't hurt to disable these anyways