### PR TITLE
Bucket name helper method

### DIFF
--- a/lib/identity/hostdata.rb
+++ b/lib/identity/hostdata.rb
@@ -84,29 +84,30 @@ module Identity
       @ec2 ||= Identity::Hostdata::EC2.load
     end
 
+    # @return [String]
+    def self.bucket_name(name)
+      "#{name}.#{aws_account_id}-#{aws_region}"
+    end
+
     # @return [S3] An S3 object configured to use the app-secrets bucket
     def self.app_secrets_s3(logger: default_logger, s3_client: nil)
-      bucket = "login-gov.app-secrets.#{aws_account_id}-#{aws_region}"
-
       Identity::Hostdata::S3.new(
         env: env,
         region: aws_region,
         logger: logger,
         s3_client: s3_client,
-        bucket: bucket
+        bucket: bucket_name('login-gov.app-secrets')
       )
     end
 
     # @return [S3] An S3 object configured to use the secrets bucket
     def self.secrets_s3(logger: default_logger, s3_client: nil)
-      bucket = "login-gov.secrets.#{aws_account_id}-#{aws_region}"
-
       Identity::Hostdata::S3.new(
         env: env,
         region: aws_region,
         logger: logger,
         s3_client: s3_client,
-        bucket: bucket
+        bucket: bucket_name('login-gov.secrets')
       )
     end
 

--- a/lib/identity/hostdata/version.rb
+++ b/lib/identity/hostdata/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Identity
   module Hostdata
-    VERSION = '3.3.0'
+    VERSION = '3.4.0'
   end
 end

--- a/spec/identity/hostdata_spec.rb
+++ b/spec/identity/hostdata_spec.rb
@@ -392,6 +392,24 @@ RSpec.describe Identity::Hostdata do
     end
   end
 
+  describe '.bucket_name' do
+    before do
+      stub_request(:put, 'http://169.254.169.254/latest/api/token').
+          with(headers: { 'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '60' }).
+          to_return(body: ec2_api_token)
+      stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
+        with(headers: { 'X-aws-ec2-metadata-token' => ec2_api_token }).
+        to_return(body: {
+          'accountId' => '12345',
+          'region' => 'us-east-1',
+        }.to_json)
+    end
+
+    it 'adds in the acccount ID and region to make a bucket name' do
+      expect(Identity::Hostdata.bucket_name('aaa')).to eq('aaa.12345-us-east-1')
+    end
+  end
+
   describe '.logger' do
     it 'has a default value' do
       expect(Identity::Hostdata.logger).to be


### PR DESCRIPTION
I noticed the IDP was building these kinds of strings manually in a bunch of different places, seemed like a good opportunity to clean things up a tad, IDP PR to demo this change coming shortly