### PR TITLE
Upgrade to Ruby 2.7 image from CIMG repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # Specify the Ruby version you desire here
-      - image: circleci/ruby:2.6
+      - image: cimg/ruby:2.7
 
     working_directory: ~/identity-hostdata
     steps:


### PR DESCRIPTION
Use `cimg/ruby:2.7` instead of legacy `circleci` image.

Addresses LG-5120