### PR TITLE
Allow skipping remote config

### DIFF
--- a/lib/identity/hostdata/config_reader.rb
+++ b/lib/identity/hostdata/config_reader.rb
@@ -50,7 +50,7 @@ module Identity
 
       def app_override_configuration
         local_config_filepath = File.join(app_root, 'config', 'application.yml')
-        raw_configs = if Identity::Hostdata.in_datacenter?
+        raw_configs = if Identity::Hostdata.in_datacenter? && !ENV['LOGIN_SKIP_REMOTE_CONFIG']
                         app_secrets_s3.read_file(app_configuration_s3_path)
                       elsif File.exist?(local_config_filepath)
                         File.read(local_config_filepath)
@@ -62,7 +62,7 @@ module Identity
         return {} if role_configuration_filename.nil?
         local_config_filepath = File.join(app_root, 'config', role_configuration_filename)
 
-        raw_configs = if Identity::Hostdata.in_datacenter?
+        raw_configs = if Identity::Hostdata.in_datacenter? && !ENV['LOGIN_SKIP_REMOTE_CONFIG']
                         app_secrets_s3.read_file(role_configuration_s3_path)
                       elsif File.exist?(local_config_filepath)
                         File.read(local_config_filepath)

--- a/lib/identity/hostdata/version.rb
+++ b/lib/identity/hostdata/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Identity
   module Hostdata
-    VERSION = '3.4.1'
+    VERSION = '3.4.2'
   end
 end


### PR DESCRIPTION
Review applications are in a datacenter, but we don't want to read the remote config (yet at least). This adds an environment variable config that allows skipping reading S3.

Related to https://github.com/18F/identity-idp/pull/8854