### PR TITLE
Redo Identity::Hostdata.config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 4.0.0
+
+- **Breaking Change**: `Identity::Hostdata.config` is renamed to `Identity::Hostdata.host_config`
+
+- **Breaking Change**: `LoginGov` namespace removed
+
+- New wrapper around S3 configs: `Identity::Hostdata.config`
+
 # 3.2.0
 
 - Update to use V2 of the EC2 instance metadata service

--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ Identity::Hostdata.domain
 # => "login.gov"
 ```
 
+Set configs from YML files in S3
+
+```ruby
+Identity::Hostdata.load_config!(
+  app_root: Rails.root,
+  rails_env: Rails.env
+) do |builder|
+  builder.add(:some_option, type: :string)
+  builder.add(:other_option, type: :json)
+end
+
+Identity::Hostdata.config.some_option
+# => "value"
+```
+
 Download configs from S3:
 
 ```ruby

--- a/identity-hostdata.gemspec
+++ b/identity-hostdata.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '>= 6.1', '< 8'
   spec.add_dependency 'aws-sdk-s3', '~> 1.8'
+  spec.add_dependency 'redacted_struct', '>= 2.0'
 
   spec.add_development_dependency "bundler", ">= 1.15"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/identity/hostdata.rb
+++ b/lib/identity/hostdata.rb
@@ -30,8 +30,8 @@ module Identity
     end
 
     # @return [Hash] parses the environment's config JSON
-    def self.config
-      return @config if defined?(@config)
+    def self.host_config
+      return @host_config if defined?(@host_config)
 
       config_path = File.join(
         root.to_s,
@@ -41,7 +41,7 @@ module Identity
       )
       config_contents = ENV['LOGIN_HOST_CONFIG'] || File.read(config_path)
 
-      @config = JSON.parse(config_contents, symbolize_names: true)
+      @host_config = JSON.parse(config_contents, symbolize_names: true)
     rescue Errno::ENOENT => err
       raise MissingConfigError, err.message if in_datacenter?
       {}

--- a/lib/identity/hostdata/config_builder.rb
+++ b/lib/identity/hostdata/config_builder.rb
@@ -1,0 +1,104 @@
+require 'csv'
+require 'json'
+require 'redacted_struct'
+
+module Identity
+  module Hostdata
+    # Helps build configurations, has a method +#add+ for defining values and their types
+    # Retains type information on the builder itself (+#key_types+) as well as +#unused_keys+
+    class ConfigBuilder
+      CONVERTERS = {
+        # Allows loading a string configuration from a system environment variable
+        # ex: To read DATABASE_HOST from system environment for the database_host key
+        # database_host: ['env', 'DATABASE_HOST']
+        # To use a string value directly, you can specify a string explicitly:
+        # database_host: 'localhost'
+        string: proc do |value|
+          if value.is_a?(Array) && value.length == 2 && value.first == 'env'
+            ENV.fetch(value[1])
+          elsif value.is_a?(String)
+            value
+          else
+            raise 'invalid system environment configuration value'
+          end
+        end,
+        symbol: proc { |value| value.to_sym },
+        comma_separated_string_list: proc do |value|
+          CSV.parse_line(value).to_a
+        end,
+        integer: proc do |value|
+          Integer(value)
+        end,
+        float: proc do |value|
+          Float(value)
+        end,
+        json: proc do |value, options: {}|
+          JSON.parse(value, symbolize_names: options[:symbolize_names])
+        end,
+        boolean: proc do |value|
+          case value
+          when 'true', true
+            true
+          when 'false', false
+            false
+          else
+            raise 'invalid boolean value'
+          end
+        end,
+        date: proc { |value| Date.parse(value) if value },
+        timestamp: proc do |value|
+          # When the store is built `Time.zone` is not set resulting in a NoMethodError
+          # if Time.zone.parse is called
+          #
+          # rubocop:disable Rails/TimeZone
+          Time.parse(value)
+          # rubocop:enable Rails/TimeZone
+        end,
+      }.freeze
+
+      attr_reader :key_types, :unused_keys
+
+      def initialize
+        @written_env = {}
+        @key_types = {}
+      end
+
+      def add(key, type: :string, allow_nil: false, enum: nil, options: {})
+        value = @read_env[key]
+
+        key_types[key] = type
+
+        converted_value = CONVERTERS.fetch(type).call(value, options: options) if !value.nil?
+        raise "#{key} is required but is not present" if converted_value.nil? && !allow_nil
+        if enum && !(enum.include?(converted_value) || (converted_value.nil? && allow_nil))
+          raise "unexpected #{key}: #{value}, expected one of #{enum}"
+        end
+
+        @written_env[key] = converted_value.freeze
+      end
+
+      # @param [Hash] values the configuration values to read from to populate the config
+      # @yieldparam [ConfigBuilder] builder for defining configuration values and types
+      # @return [RedactedStruct]
+      # @example
+      #   struct = config_builder.build!(values) do |builder|
+      #              builder.add(:my_key, type: :string)
+      #            end
+      def build!(values)
+        @read_env = values
+
+        yield self
+
+        key_types.freeze
+        @unused_keys = (@read_env.keys - @written_env.keys).freeze
+        @written_env.freeze
+
+        # Clear out @read_env to minimize the chance sensitive values get logged
+        @read_env = nil
+
+        RedactedStruct.new(*@written_env.keys, keyword_init: true).
+          new(**@written_env)
+      end
+    end
+  end
+end

--- a/lib/identity/hostdata/version.rb
+++ b/lib/identity/hostdata/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Identity
   module Hostdata
-    VERSION = '3.4.3'
+    VERSION = '4.0.0'
   end
 end

--- a/lib/login_gov/hostdata.rb
+++ b/lib/login_gov/hostdata.rb
@@ -1,6 +1,0 @@
-require 'identity/hostdata'
-
-# Create an alias with the old LoginGov namespace so we don't break some of our configs
-module LoginGov
-  Hostdata = ::Identity::Hostdata
-end

--- a/spec/identity/hostdata/config_builder_spec.rb
+++ b/spec/identity/hostdata/config_builder_spec.rb
@@ -1,9 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Identity::Hostdata::ConfigBuilder do
-  subject(:config_builder) do
-    Identity::Hostdata::ConfigBuilder.new
-  end
+  subject(:config_builder) { Identity::Hostdata::ConfigBuilder.new }
 
   describe '::CONVERTERS' do
     describe 'comma_separated_string_list' do
@@ -22,6 +20,69 @@ RSpec.describe Identity::Hostdata::ConfigBuilder do
 
         expect(config.csv_value).to eq([])
       end
+    end
+  end
+
+  before do
+    stub_const('ENV', { 'SOME_ENV_VAR' => 'eee' })
+  end
+
+  let(:values) do
+    {
+      string_key: 'aaa',
+      boolean_key: true,
+      int_key: 111,
+      commas_key: 'a,b,c',
+      json_array: '["d","e","f"]',
+      string_env_key: ['env', 'SOME_ENV_VAR'],
+      never_used_key: 'never'
+    }
+  end
+
+  subject(:build!) do
+    config_builder.build!(values) do |builder|
+      builder.add(:string_key, type: :string)
+      builder.add(:boolean_key, type: :boolean)
+      builder.add(:int_key, type: :integer)
+      builder.add(:commas_key, type: :comma_separated_string_list)
+      builder.add(:json_array, type: :json)
+      builder.add(:string_env_key)
+    end
+  end
+
+  describe '#build!' do
+    it 'returns a struct with the values parsed correctly' do
+      result = build!
+
+      expect(result.string_key).to eq('aaa')
+      expect(result.boolean_key).to eq(true)
+      expect(result.int_key).to eq(111)
+      expect(result.commas_key).to eq(%w[a b c ])
+      expect(result.json_array).to eq(%w[d e f])
+      expect(result.string_env_key).to eq('eee')
+    end
+  end
+
+  describe '#key_types' do
+    it 'tracks key types' do
+      build!
+
+      expect(config_builder.key_types).to eq(
+        string_key: :string,
+        boolean_key: :boolean,
+        int_key: :integer,
+        commas_key: :comma_separated_string_list,
+        json_array: :json,
+        string_env_key: :string,
+      )
+    end
+  end
+
+  describe '#unused_keys' do
+    it 'tracks unused keys' do
+      build!
+
+      expect(config_builder.unused_keys).to eq([:never_used_key])
     end
   end
 end

--- a/spec/identity/hostdata/config_builder_spec.rb
+++ b/spec/identity/hostdata/config_builder_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+RSpec.describe Identity::Hostdata::ConfigBuilder do
+  subject(:config_builder) do
+    Identity::Hostdata::ConfigBuilder.new
+  end
+
+  describe '::CONVERTERS' do
+    describe 'comma_separated_string_list' do
+      it 'respects double-quotes for embedded commas' do
+        config = config_builder.build!({ csv_value: 'one,two,"three,four"' }) do |builder|
+          builder.add(:csv_value, type: :comma_separated_string_list)
+        end
+
+        expect(config.csv_value).to eq(['one', 'two', 'three,four'])
+      end
+
+      it 'parses empty value as empty array' do
+        config = config_builder.build!({ csv_value: '' }) do |builder|
+          builder.add(:csv_value, type: :comma_separated_string_list)
+        end
+
+        expect(config.csv_value).to eq([])
+      end
+    end
+  end
+end

--- a/spec/identity/hostdata_spec.rb
+++ b/spec/identity/hostdata_spec.rb
@@ -433,6 +433,7 @@ RSpec.describe Identity::Hostdata do
       end
 
       expect(Identity::Hostdata.config.config_value).to eq('prod_override')
+      expect(Identity::Hostdata.config_builder.key_types).to include(config_value: :string)
     end
   end
 end

--- a/spec/identity/hostdata_spec.rb
+++ b/spec/identity/hostdata_spec.rb
@@ -243,7 +243,7 @@ RSpec.describe Identity::Hostdata do
     end
   end
 
-  describe '.config' do
+  describe '.host_config' do
     let(:config_data) do
       {
         description: 'the staging data',
@@ -269,13 +269,13 @@ RSpec.describe Identity::Hostdata do
         end
 
         it 'parses the contents of the file' do
-          expect(Identity::Hostdata.config).to eq(config_data)
+          expect(Identity::Hostdata.host_config).to eq(config_data)
         end
       end
 
       context 'when the info/env file does not exist' do
         it 'blows up' do
-          expect { Identity::Hostdata.config }.
+          expect { Identity::Hostdata.host_config }.
             to raise_error(Identity::Hostdata::MissingConfigError)
         end
       end
@@ -292,13 +292,13 @@ RSpec.describe Identity::Hostdata do
       end
 
       it 'parses and returns the config in the env' do
-        expect(Identity::Hostdata.config).to eq(config_data)
+        expect(Identity::Hostdata.host_config).to eq(config_data)
       end
     end
 
     context 'when /etc/login.gov does not exist (development environment)' do
       it 'is an empty hash' do
-        expect(Identity::Hostdata.config).to eq({})
+        expect(Identity::Hostdata.host_config).to eq({})
       end
     end
   end

--- a/spec/identity/login_gov/hostdata_spec.rb
+++ b/spec/identity/login_gov/hostdata_spec.rb
@@ -1,8 +1,0 @@
-RSpec.describe 'backwards-compatible name' do
-  it 'exists' do
-    expect do
-      require 'login_gov/hostdata'
-      LoginGov::Hostdata.env
-    end.to_not raise_error
-  end
-end


### PR DESCRIPTION
This is an idea that's been floating around in my head for a bit, so I went for it. IDP PR coming soon as a demo

- Pull the `IdentityConfig` class we have copied into our various apps into the shared gem.
- Renames the old "config" (valuable short name) to host_config

