### PR TITLE
Add method to load secrets from SecretsManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.1.0
+
+- Add `ConfigBuilder#add_ssm` to load secrets from SSM
+
 # 4.0.0
 
 - **Breaking Change**: `Identity::Hostdata.config` is renamed to `Identity::Hostdata.host_config`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 4.1.0
 
-- Add `ConfigBuilder#add_ssm` to load secrets from SSM
+- Add AWS Secrets Manager support to `ConfigBuilder#add`
 
 # 4.0.0
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ Identity::Hostdata.load_config!(
   builder.add(:prop_name, secrets_manager_name: 'secrets-manager-name', type: :string)
   builder.add(
     :other_prop,
-    secrets_manager_name: "secrets-manager-dynamic-#{Identity::Hostdata.env}",
-    secrets_manager_local_name: "secrets-manager-dynamic-env",
+    secrets_manager_name: "secrets-manager-dynamic-#{Identity::Hostdata.env || 'local'}",
     type: :string,
   )
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,14 @@ Identity::Hostdata.load_config!(
   builder.add(:some_option, type: :string)
   builder.add(:other_option, type: :json)
 
-  # SSM
+  # Secrets Manager
   builder.add(:prop_name, secrets_manager_name: 'secrets-manager-name', type: :string)
+  builder.add(
+    :other_prop,
+    secrets_manager_name: "secrets-manager-dynamic-#{Identity::Hostdata.env}",
+    secrets_manager_local_name: "secrets-manager-dynamic-env",
+    type: :string,
+  )
 
   # custom parsing of values
   builder.add(:other_prop_name, type: :string) do |raw|

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Identity::Hostdata.domain
 # => "login.gov"
 ```
 
-Set configs from YML files in S3 or SSM
+Set configs from YML files in S3 or Secrets Manager
 
 ```ruby
 Identity::Hostdata.load_config!(
@@ -33,7 +33,12 @@ Identity::Hostdata.load_config!(
   builder.add(:other_option, type: :json)
 
   # SSM
-  builder.add_ssm(:prop_name, 'ssm-name-goes-here', type: :string)
+  builder.add(:prop_name, secrets_manager_name: 'secrets-manager-name', type: :string)
+
+  # custom parsing of values
+  builder.add(:other_prop_name, type: :string) do |raw|
+    JSON.parse(raw)['nested-key']
+  end
 end
 
 Identity::Hostdata.config.some_option

--- a/README.md
+++ b/README.md
@@ -21,15 +21,19 @@ Identity::Hostdata.domain
 # => "login.gov"
 ```
 
-Set configs from YML files in S3
+Set configs from YML files in S3 orSSM
 
 ```ruby
 Identity::Hostdata.load_config!(
   app_root: Rails.root,
   rails_env: Rails.env
 ) do |builder|
+  # YML
   builder.add(:some_option, type: :string)
   builder.add(:other_option, type: :json)
+
+  # SSM
+  builder.add_ssm(:prop_name, 'ssm-name-goes-here', type: :string)
 end
 
 Identity::Hostdata.config.some_option

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Identity::Hostdata.domain
 # => "login.gov"
 ```
 
-Set configs from YML files in S3 orSSM
+Set configs from YML files in S3 or SSM
 
 ```ruby
 Identity::Hostdata.load_config!(

--- a/identity-hostdata.gemspec
+++ b/identity-hostdata.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '>= 6.1', '< 8'
   spec.add_dependency 'aws-sdk-s3', '~> 1.8'
-  spec.add_dependency 'aws-sdk-ssm', '~> 1.167.0'
+  spec.add_dependency 'aws-sdk-secretsmanager', '>= 1.91'
   spec.add_dependency 'redacted_struct', '>= 2.0'
 
   spec.add_development_dependency "bundler", ">= 1.15"

--- a/identity-hostdata.gemspec
+++ b/identity-hostdata.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '>= 6.1', '< 8'
   spec.add_dependency 'aws-sdk-s3', '~> 1.8'
+  spec.add_dependency 'aws-sdk-ssm', '~> 1.167.0'
   spec.add_dependency 'redacted_struct', '>= 2.0'
 
   spec.add_development_dependency "bundler", ">= 1.15"

--- a/lib/identity/hostdata/config_builder.rb
+++ b/lib/identity/hostdata/config_builder.rb
@@ -117,7 +117,7 @@ module Identity
       end
 
       def secrets_client
-        @secrets_client ||= Aws::SSM::SecretsManager.new(
+        @secrets_client ||= Aws::SecretsManager::Client.new(
           http_idle_timeout: 5,
           http_open_timeout: 5,
           http_read_timeout: 5,

--- a/lib/identity/hostdata/config_builder.rb
+++ b/lib/identity/hostdata/config_builder.rb
@@ -93,11 +93,6 @@ module Identity
         @written_env[key] = converted_value.freeze
       end
 
-      # @api private
-      def convert!(key:, value:, type:, allow_nil:, enum:, options:)
-        converted_value
-      end
-
       # @param [Hash] values the configuration values to read from to populate the config
       # @yieldparam [ConfigBuilder] builder for defining configuration values and types
       # @return [RedactedStruct]

--- a/lib/identity/hostdata/config_builder.rb
+++ b/lib/identity/hostdata/config_builder.rb
@@ -73,7 +73,11 @@ module Identity
         options: {}
       )
         value = if secrets_manager_name
-          secrets_client.get_secret_value(secret_id: secrets_manager_name).secret_string
+          if Identity::Hostdata.in_datacenter?
+            secrets_client.get_secret_value(secret_id: secrets_manager_name).secret_string
+          else
+            @read_env[secrets_manager_name.to_sym]
+          end
         else
           @read_env[key]
         end

--- a/lib/identity/hostdata/config_builder.rb
+++ b/lib/identity/hostdata/config_builder.rb
@@ -133,6 +133,7 @@ module Identity
 
       def secrets_client
         @secrets_client ||= Aws::SecretsManager::Client.new(
+          region: Identity::Hostdata.aws_region,
           http_idle_timeout: 5,
           http_open_timeout: 5,
           http_read_timeout: 5,

--- a/lib/identity/hostdata/config_builder.rb
+++ b/lib/identity/hostdata/config_builder.rb
@@ -67,9 +67,6 @@ module Identity
       # @param key [Symbol] secret property name
       # @param secrets_manager_name [String] if present, the secret_id for Secrets Manager to get
       #   the value from in a deployed environment
-      # @param secrets_manager_local_name [String] if present, the key to look up a local equivalent
-      #   of a Secrets Manager secret in local development. When absent, +secrets_manager_name+ is
-      #   used locally
       # @param type [Symbol] secret type, used to parse raw value
       # @param allow_nil [Boolean] whether or not a nil value is allowed
       # @param enum [nil, Array] list of allowed values
@@ -77,7 +74,6 @@ module Identity
       def add(
         key,
         secrets_manager_name: nil,
-        secrets_manager_local_name: nil,
         type: :string,
         allow_nil: false,
         enum: nil,
@@ -87,7 +83,7 @@ module Identity
           if Identity::Hostdata.in_datacenter?
             secrets_client.get_secret_value(secret_id: secrets_manager_name).secret_string
           else
-            @read_env[(secrets_manager_local_name || secrets_manager_name).to_sym]
+            @read_env[secrets_manager_name.to_sym]
           end
         else
           @read_env[key]

--- a/lib/identity/hostdata/config_builder.rb
+++ b/lib/identity/hostdata/config_builder.rb
@@ -64,9 +64,20 @@ module Identity
         @key_types = {}
       end
 
+      # @param key [Symbol] secret property name
+      # @param secrets_manager_name [String] if present, the secret_id for Secrets Manager to get
+      #   the value from in a deployed environment
+      # @param secrets_manager_local_name [String] if present, the key to look up a local equivalent
+      #   of a Secrets Manager secret in local development. When absent, +secrets_manager_name+ is
+      #   used locally
+      # @param type [Symbol] secret type, used to parse raw value
+      # @param allow_nil [Boolean] whether or not a nil value is allowed
+      # @param enum [nil, Array] list of allowed values
+      # @param options [Hash] options hash, passed to per-type converter
       def add(
         key,
         secrets_manager_name: nil,
+        secrets_manager_local_name: nil,
         type: :string,
         allow_nil: false,
         enum: nil,
@@ -76,7 +87,7 @@ module Identity
           if Identity::Hostdata.in_datacenter?
             secrets_client.get_secret_value(secret_id: secrets_manager_name).secret_string
           else
-            @read_env[secrets_manager_name.to_sym]
+            @read_env[(secrets_manager_local_name || secrets_manager_name).to_sym]
           end
         else
           @read_env[key]

--- a/lib/identity/hostdata/version.rb
+++ b/lib/identity/hostdata/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Identity
   module Hostdata
-    VERSION = '4.0.0'
+    VERSION = '4.1.0'
   end
 end

--- a/spec/identity/hostdata/config_builder_spec.rb
+++ b/spec/identity/hostdata/config_builder_spec.rb
@@ -26,14 +26,15 @@ RSpec.describe Identity::Hostdata::ConfigBuilder do
   before do
     stub_const('ENV', { 'SOME_ENV_VAR' => 'eee' })
 
-    allow(config_builder).to receive(:secrets_client).
-      and_return(Aws::SecretsManager::Client.new(stub_responses: {
+    Aws.config[:secretsmanager] = {
+      stub_responses: {
         get_secret_value: proc do |context|
           {
             secret_string: secrets_manager_values.fetch(context.params[:secret_id]),
           }
         end,
-      }))
+      }
+    }
   end
 
   let(:secrets_manager_values) do

--- a/spec/identity/hostdata/config_builder_spec.rb
+++ b/spec/identity/hostdata/config_builder_spec.rb
@@ -36,6 +36,8 @@ RSpec.describe Identity::Hostdata::ConfigBuilder do
     )
 
     if in_datacenter
+      stub_ec2_metadata
+
       Aws.config[:secretsmanager] = {
         stub_responses: {
           get_secret_value: proc do |context|

--- a/spec/identity/hostdata/config_builder_spec.rb
+++ b/spec/identity/hostdata/config_builder_spec.rb
@@ -86,7 +86,6 @@ RSpec.describe Identity::Hostdata::ConfigBuilder do
       builder.add(
         :redshift_password,
         secrets_manager_name: 'redshift!example-awsuser',
-        secrets_manager_local_name: 'redshift_local_override',
         type: :string
       ) do |raw|
         JSON.parse(raw).fetch('password')
@@ -118,8 +117,10 @@ RSpec.describe Identity::Hostdata::ConfigBuilder do
 
       let(:values) do
         super().merge(
-          :'redshift!example-awsuser' => { 'username' => 'local-username' }.to_json,
-          redshift_local_override: { 'password' => 'local-password' }.to_json,
+          :'redshift!example-awsuser' => {
+            'username' => 'local-username',
+            'password' => 'local-password',
+          }.to_json,
         )
       end
 

--- a/spec/identity/hostdata/config_builder_spec.rb
+++ b/spec/identity/hostdata/config_builder_spec.rb
@@ -81,6 +81,14 @@ RSpec.describe Identity::Hostdata::ConfigBuilder do
       ) do |raw|
         JSON.parse(raw).fetch('username')
       end
+      builder.add(
+        :redshift_password,
+        secrets_manager_name: 'redshift!example-awsuser',
+        secrets_manager_local_name: 'redshift_local_override',
+        type: :string
+      ) do |raw|
+        JSON.parse(raw).fetch('password')
+      end
     end
   end
 
@@ -99,6 +107,7 @@ RSpec.describe Identity::Hostdata::ConfigBuilder do
         expect(result.string_env_key).to eq('eee')
 
         expect(result.redshift_username).to eq('ssm-username')
+        expect(result.redshift_password).to eq('pass')
       end
     end
 
@@ -108,6 +117,7 @@ RSpec.describe Identity::Hostdata::ConfigBuilder do
       let(:values) do
         super().merge(
           :'redshift!example-awsuser' => { 'username' => 'local-username' }.to_json,
+          redshift_local_override: { 'password' => 'local-password' }.to_json,
         )
       end
 
@@ -121,6 +131,7 @@ RSpec.describe Identity::Hostdata::ConfigBuilder do
         result = build!
 
         expect(result.redshift_username).to eq('local-username')
+        expect(result.redshift_password).to eq('local-password')
       end
     end
   end
@@ -137,6 +148,7 @@ RSpec.describe Identity::Hostdata::ConfigBuilder do
         json_array: :json,
         string_env_key: :string,
         redshift_username: :string,
+        redshift_password: :string,
       )
     end
   end

--- a/spec/identity/hostdata_spec.rb
+++ b/spec/identity/hostdata_spec.rb
@@ -21,20 +21,6 @@ RSpec.describe Identity::Hostdata do
     stub_const('ENV', env)
   end
 
-  def stub_ec2_metadata
-    ec2_api_token = SecureRandom.hex
-
-    stub_request(:put, 'http://169.254.169.254/latest/api/token').
-      with(headers: { 'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '60' }).
-      to_return(body: ec2_api_token)
-    stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
-      with(headers: { 'X-aws-ec2-metadata-token' => ec2_api_token }).
-      to_return(body: {
-        'accountId' => '12345',
-        'region' => 'us-east-1',
-      }.to_json)
-  end
-
   describe '.domain' do
     context 'when /etc/login.gov exists (in a datacenter environment)' do
       before { FileUtils.mkdir_p("#{@root}/etc/login.gov") }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require "bundler/setup"
 require "identity/hostdata"
 require "pp"
+require "support/ec2_helpers"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -12,6 +13,8 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.include(Ec2Helpers)
 end
 
 require 'webmock/rspec'

--- a/spec/support/ec2_helpers.rb
+++ b/spec/support/ec2_helpers.rb
@@ -1,0 +1,13 @@
+module Ec2Helpers
+  def stub_ec2_metadata(ec2_api_token: SecureRandom.hex)
+    stub_request(:put, 'http://169.254.169.254/latest/api/token').
+      with(headers: { 'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '60' }).
+      to_return(body: ec2_api_token)
+    stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
+      with(headers: { 'X-aws-ec2-metadata-token' => ec2_api_token }).
+      to_return(body: {
+        'accountId' => '12345',
+        'region' => 'us-east-1',
+      }.to_json)
+  end
+end


### PR DESCRIPTION
Based on some upcoming data warehouse changes, we're going to store secrets in AWS Secrets Manager [(gitlab link)](https://gitlab.login.gov/lg/identity-devops/-/merge_requests/4533#note_174053)

This PR is an attempt to augment `Identity::Hostdata` config so that we can load those.

~Since SSM secrets have different name styles than our YML secrets, I opted for a new method, `add_ssm`.~

In this particular case, we have a JSON blob inside of the secret with two keys, so I added a block arg to let us process and yield out just the one value