### PR TITLE
Add Secrets Manager as a source for configuration values

### DIFF
--- a/identity-hostdata.gemspec
+++ b/identity-hostdata.gemspec
@@ -39,4 +39,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 3.0.1"
+  spec.add_development_dependency "rexml"
 end

--- a/lib/identity/hostdata/config_builder.rb
+++ b/lib/identity/hostdata/config_builder.rb
@@ -100,12 +100,16 @@ module Identity
       end
 
       def fetch_value_from_source(key, value)
-        if value.is_a?(Array) && value.length == 2 && value.first == 'env'
-          ENV.fetch(value[1])
-        elsif value.is_a?(Array) && value.length == 2 && value.first == 'secrets_manager'
-          secrets_client.get_secret_value(secret_id: value[1]).secret_string
-        elsif value.is_a?(Array)
-          raise "invalid configuration value for #{key}"
+        if value.is_a?(Array)
+          type, name, *rest = value
+          case type
+          when 'env'
+            ENV.fetch(name)
+          when 'secrets_manager'
+            secrets_client.get_secret_value(secret_id: name).secret_string
+          else
+            raise "invalid configuration value for #{key}"
+          end
         else
           value
         end

--- a/lib/identity/hostdata/version.rb
+++ b/lib/identity/hostdata/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Identity
   module Hostdata
-    VERSION = '4.1.0'
+    VERSION = '4.2.0'
   end
 end

--- a/spec/identity/hostdata/config_builder_spec.rb
+++ b/spec/identity/hostdata/config_builder_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe Identity::Hostdata::ConfigBuilder do
         string_env_key: :string,
         redshift_username: :string,
         redshift_password: :string,
-        :string_secrets_manager_key => :string,
+        string_secrets_manager_key: :string,
       )
     end
   end

--- a/spec/identity/hostdata/config_builder_spec.rb
+++ b/spec/identity/hostdata/config_builder_spec.rb
@@ -31,13 +31,13 @@ RSpec.describe Identity::Hostdata::ConfigBuilder do
       'ENV',
       {
         'SOME_ENV_VAR' => 'eee',
+        'LOGIN_AWS_REGION' => 'us-west-2',
         'LOGIN_DATACENTER' => (in_datacenter ? 'true' : nil),
       },
     )
 
     if in_datacenter
       stub_ec2_metadata
-
       Aws.config[:secretsmanager] = {
         stub_responses: {
           get_secret_value: proc do |context|
@@ -49,11 +49,13 @@ RSpec.describe Identity::Hostdata::ConfigBuilder do
       }
     end
   end
+
   after { Identity::Hostdata.reset! }
 
   let(:secrets_manager_values) do
     {
-      'redshift!example-awsuser' => { 'username' => 'ssm-username', 'password' => 'pass' }.to_json
+      'redshift!example-awsuser' => { 'username' => 'ssm-username', 'password' => 'pass' }.to_json,
+      'my_secrets_manager_key' => 'secrets_manager_secret',
     }
   end
   let(:values) do
@@ -64,6 +66,7 @@ RSpec.describe Identity::Hostdata::ConfigBuilder do
       commas_key: 'a,b,c',
       json_array: '["d","e","f"]',
       string_env_key: ['env', 'SOME_ENV_VAR'],
+      string_secrets_manager_key: ['secrets_manager', 'my_secrets_manager_key'],
       never_used_key: 'never'
     }
   end
@@ -90,6 +93,7 @@ RSpec.describe Identity::Hostdata::ConfigBuilder do
       ) do |raw|
         JSON.parse(raw).fetch('password')
       end
+      builder.add(:string_secrets_manager_key)
     end
   end
 
@@ -109,6 +113,8 @@ RSpec.describe Identity::Hostdata::ConfigBuilder do
 
         expect(result.redshift_username).to eq('ssm-username')
         expect(result.redshift_password).to eq('pass')
+
+        expect(result.string_secrets_manager_key).to eq('secrets_manager_secret')
       end
     end
 
@@ -136,6 +142,19 @@ RSpec.describe Identity::Hostdata::ConfigBuilder do
         expect(result.redshift_username).to eq('local-username')
         expect(result.redshift_password).to eq('local-password')
       end
+
+      context 'without secrets manager keys' do
+        let(:values) do
+          super().merge(string_secrets_manager_key: 'abc')
+        end
+
+        it 'does not call AWS at all' do
+          result = build!
+
+          expect(a_request(:any, /.*/)).to have_not_been_made
+          expect(result.string_secrets_manager_key).to eq('abc')
+        end
+      end
     end
   end
 
@@ -152,6 +171,7 @@ RSpec.describe Identity::Hostdata::ConfigBuilder do
         string_env_key: :string,
         redshift_username: :string,
         redshift_password: :string,
+        :string_secrets_manager_key => :string,
       )
     end
   end


### PR DESCRIPTION
Similar to #40, but with a slightly different approach. This PR is in draft status for now to help move towards something that can accommodate the multiple use cases we may have for secrets manager usage in applications.