### PR TITLE
Refactor EC2 in specs to use shared EC2Helpers module

### DIFF
--- a/spec/identity/hostdata/config_reader_spec.rb
+++ b/spec/identity/hostdata/config_reader_spec.rb
@@ -45,22 +45,13 @@ RSpec.describe Identity::Hostdata::ConfigReader do
         'int/idp/v1/worker.yml' => ROLE_YAML,
       }
     end
-    let(:ec2_api_token) { SecureRandom.hex }
 
     before do
       allow(Identity::Hostdata).to receive(:in_datacenter?).and_return(true)
       allow(Identity::Hostdata).to receive(:instance_role).and_return('idp')
       allow(Identity::Hostdata).to receive(:env).and_return('int')
 
-      stub_request(:put, 'http://169.254.169.254/latest/api/token').
-          with(headers: { 'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '60' }).
-          to_return(body: ec2_api_token)
-      stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
-          with(headers: { 'X-aws-ec2-metadata-token' => ec2_api_token }).
-          to_return(body: {
-            'region' => 'us-west-1',
-            'accountId' => '12345',
-          }.to_json)
+      stub_ec2_metadata
 
       s3_client.stub_responses(
         :get_object, proc do |context|

--- a/spec/identity/hostdata/ec2_spec.rb
+++ b/spec/identity/hostdata/ec2_spec.rb
@@ -4,21 +4,16 @@ RSpec.describe Identity::Hostdata::EC2 do
   describe '.load' do
     subject(:load) { Identity::Hostdata::EC2.load }
 
-    let(:ec2_api_token) { SecureRandom.hex }
-
     it 'loads data from the magic ECS URL' do
-      stub_request(:put, 'http://169.254.169.254/latest/api/token').
-          with(headers: { 'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '60' }).
-          to_return(body: ec2_api_token)
-      stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
-        with(headers: { 'X-aws-ec2-metadata-token' => ec2_api_token }).
-        to_return(body: document.to_json)
+      stub_ec2_metadata(document: document)
 
       ec2 = load
       expect(ec2.region).to eq('us-west-2')
     end
 
     it 'blows up when the request times out' do
+      ec2_api_token = SecureRandom.hex
+
       stub_request(:put, 'http://169.254.169.254/latest/api/token').
           with(headers: { 'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '60' }).
           to_return(body: ec2_api_token)

--- a/spec/identity/hostdata/ec2_spec.rb
+++ b/spec/identity/hostdata/ec2_spec.rb
@@ -1,6 +1,25 @@
 require 'spec_helper'
 
 RSpec.describe Identity::Hostdata::EC2 do
+  let(:document) do
+    {
+      'privateIp' => '172.16.33.170',
+      'devpayProductCodes' => nil,
+      'availabilityZone' => 'us-west-2b',
+      'version' => '2010-08-31',
+      'instanceId' => 'i-12345',
+      'billingProducts' => nil,
+      'instanceType' => 'c3.xlarge',
+      'accountId' => '12345',
+      'architecture' => 'x86_64',
+      'kernelId' => nil,
+      'ramdiskId' => nil,
+      'imageId' => 'ami-7e22c506',
+      'pendingTime' => '2017-08-24T18:10:24Z',
+      'region' => 'us-west-2',
+    }
+  end
+
   describe '.load' do
     subject(:load) { Identity::Hostdata::EC2.load }
 
@@ -23,25 +42,6 @@ RSpec.describe Identity::Hostdata::EC2 do
 
       expect { load }.to raise_error(Net::OpenTimeout)
     end
-  end
-
-  let(:document) do
-    {
-      'privateIp' => '172.16.33.170',
-      'devpayProductCodes' => nil,
-      'availabilityZone' => 'us-west-2b',
-      'version' => '2010-08-31',
-      'instanceId' => 'i-12345',
-      'billingProducts' => nil,
-      'instanceType' => 'c3.xlarge',
-      'accountId' => '12345',
-      'architecture' => 'x86_64',
-      'kernelId' => nil,
-      'ramdiskId' => nil,
-      'imageId' => 'ami-7e22c506',
-      'pendingTime' => '2017-08-24T18:10:24Z',
-      'region' => 'us-west-2',
-    }
   end
 
   subject(:ec2) { Identity::Hostdata::EC2.new(document) }

--- a/spec/support/ec2_helpers.rb
+++ b/spec/support/ec2_helpers.rb
@@ -1,13 +1,15 @@
 module Ec2Helpers
-  def stub_ec2_metadata(ec2_api_token: SecureRandom.hex)
+  def stub_ec2_metadata(ec2_api_token: SecureRandom.hex, document: nil)
+    document ||= {
+      'accountId' => '12345',
+      'region' => 'us-east-1',
+    }
+
     stub_request(:put, 'http://169.254.169.254/latest/api/token').
       with(headers: { 'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '60' }).
       to_return(body: ec2_api_token)
     stub_request(:get, 'http://169.254.169.254/2016-09-02/dynamic/instance-identity/document').
       with(headers: { 'X-aws-ec2-metadata-token' => ec2_api_token }).
-      to_return(body: {
-        'accountId' => '12345',
-        'region' => 'us-east-1',
-      }.to_json)
+      to_return(body: document.to_json)
   end
 end


### PR DESCRIPTION
I added `EC2Helpers` in #40 out of necessity, this PR just follows up and update the rest of the test suite to use it.