### PR TITLE
Update gems and CI Ruby version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # Specify the Ruby version you desire here
-      - image: cimg/ruby:2.7
+      - image: cimg/ruby:3.2
 
     working_directory: ~/identity-hostdata
     steps:

--- a/identity-hostdata.gemspec
+++ b/identity-hostdata.gemspec
@@ -35,8 +35,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aws-sdk-secretsmanager', '>= 1.91'
   spec.add_dependency 'redacted_struct', '>= 2.0'
 
-  spec.add_development_dependency "bundler", ">= 1.15"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", ">= 2.5"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 3.0.1"
   spec.add_development_dependency "rexml"


### PR DESCRIPTION
The current `rake` version specified is quite old (last version of 10.x was in January 2016) and is not compatible with newer versions of Ruby.

This PR updates both the Ruby version used in CI as well as the rake and bundler gems.